### PR TITLE
Add Portuguese translations for story steps

### DIFF
--- a/src/app/[locale]/tell-your-story/step-1/page.tsx
+++ b/src/app/[locale]/tell-your-story/step-1/page.tsx
@@ -4,7 +4,7 @@ import { SignedIn, SignedOut } from '@clerk/nextjs';
 import Link from 'next/link';
 import StepNavigation from '../../../../components/StepNavigation';
 import { useState, useEffect } from 'react';
-import { useLocale } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 
 interface AuthorData {
   authorId: string;
@@ -19,10 +19,10 @@ interface AuthorData {
 
 export default function Step1Page() {
   const locale = useLocale();
+  const t = useTranslations('StorySteps.step1');
   const [, setAuthorData] = useState<AuthorData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [successMessage, setSuccessMessage] = useState<string | null>(null);
   
   // Form data
   const [displayName, setDisplayName] = useState('');
@@ -56,7 +56,7 @@ export default function Step1Page() {
   };
     const handleNext = async (): Promise<boolean> => {
     if (!displayName || !email) {
-      setError('Please fill in all required fields');
+      setError(t('messages.required'));
       return false; // Prevent navigation
     }
 
@@ -81,7 +81,7 @@ export default function Step1Page() {
       return true; // Allow navigation
     } catch (err) {
       console.error('Failed to save profile:', err);
-      setError('Failed to save profile. Please try again.');
+      setError(t('messages.saveFailed'));
       return false; // Prevent navigation
     } finally {
       setLoading(false);
@@ -95,7 +95,7 @@ export default function Step1Page() {
       const response = await fetch('/api/auth/me');
       
       if (!response.ok) {
-        throw new Error('Failed to fetch user data');
+        throw new Error(t('messages.fetchFailed'));
       }
       
       const data: AuthorData = await response.json();
@@ -122,7 +122,7 @@ export default function Step1Page() {
       
     } catch (error) {
       console.error('Error fetching author data:', error);
-      setError('Failed to load user information. Please try again.');
+      setError(t('messages.loadFailed'));
     } finally {
       setLoading(false);
     }
@@ -132,21 +132,21 @@ export default function Step1Page() {
     <div className="container mx-auto px-4 py-8">
       <SignedOut>
         <div className="text-center space-y-6 max-w-2xl mx-auto">
-          <div className="text-6xl">📚</div>          <h1 className="text-4xl font-bold">Oops! Looks like you&apos;re trying to sneak into the author&apos;s lounge!</h1>
+          <div className="text-6xl">📚</div>
+          <h1 className="text-4xl font-bold">{t('unauthenticated.title')}</h1>
           <p className="text-lg text-gray-600">
-            While we appreciate your enthusiasm for storytelling, you&apos;ll need to sign in first. 
-            Don&apos;t worry, it&apos;s easier than convincing a dragon to share its treasure! 🐉
+            {t('unauthenticated.description')}
           </p>
           <div className="space-x-4">
             <Link href={`/${locale}/sign-in`} className="btn btn-primary btn-lg">
-              🔐 Sign In to Start Your Adventure
+              {t('unauthenticated.signIn')}
             </Link>
             <Link href={`/${locale}/sign-up`} className="btn btn-outline btn-lg">
-              ✨ Create Your Author Account
+              {t('unauthenticated.signUp')}
             </Link>
           </div>
           <p className="text-sm text-gray-500">
-            Once you&apos;re signed in, you&apos;ll be ready to create magical stories that would make even Merlin jealous! 🧙‍♂️
+            {t('unauthenticated.note')}
           </p>
         </div>
       </SignedOut>
@@ -189,19 +189,16 @@ export default function Step1Page() {
           {/* Step content */}
           <div className="card bg-base-100 shadow-xl">
             <div className="card-body">
-              <h1 className="card-title text-3xl mb-6">Chapter 1 - The Author</h1>
+              <h1 className="card-title text-3xl mb-6">{t('heading')}</h1>
               
               {loading ? (
                 <div className="text-center py-12">
                   <span className="loading loading-spinner loading-lg"></span>
-                  <p className="text-lg text-gray-600 mt-4">Loading your author profile...</p>
+                  <p className="text-lg text-gray-600 mt-4">{t('messages.loadingProfile')}</p>
                 </div>              ) : (
                 <div className="space-y-6">
                   <div className="prose max-w-none mb-6">
-                    <p className="text-gray-600">
-                      Welcome, storyteller! Before we dive into your magical adventure,                      let&apos;s make sure we have your correct information. This helps us 
-                      personalize your experience and keep you updated on your story&apos;s progress.
-                    </p>
+                    <p className="text-gray-600">{t('intro')}</p>
                   </div>
 
                   {error && (
@@ -211,20 +208,13 @@ export default function Step1Page() {
                       </svg>
                       <span>{error}</span>
                     </div>
-                  )}                  {successMessage && (
-                    <div className="alert alert-success">
-                      <svg xmlns="http://www.w3.org/2000/svg" className="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24">
-                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" />
-                      </svg>
-                      <span>{successMessage}</span>
-                    </div>
                   )}
 
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
                     {/* Name Field */}
                     <div className="form-control">
                       <label className="label">
-                        <span className="label-text font-semibold">Full Name *</span>
+                        <span className="label-text font-semibold">{t('fields.fullName')}</span>
                       </label>                      <input
                         type="text"
                         value={displayName}
@@ -232,19 +222,19 @@ export default function Step1Page() {
                           setDisplayName(e.target.value);
                           checkForChanges(e.target.value, email, mobilePhone);
                         }}
-                        placeholder="Enter your full name"
+                        placeholder={t('fields.fullName')}
                         className="input input-bordered w-full"
                         required
                       />
                       <label className="label">
-                        <span className="label-text-alt">This is how you&apos;ll be credited as the author</span>
+                        <span className="label-text-alt">{t('fields.fullNameHelp')}</span>
                       </label>
                     </div>
 
                     {/* Email Field */}
                     <div className="form-control">
                       <label className="label">
-                        <span className="label-text font-semibold">Email Address *</span>
+                        <span className="label-text font-semibold">{t('fields.email')}</span>
                       </label>                      <input
                         type="email"
                         value={email}
@@ -252,19 +242,19 @@ export default function Step1Page() {
                           setEmail(e.target.value);
                           checkForChanges(displayName, e.target.value, mobilePhone);
                         }}
-                        placeholder="Enter your email address"
+                        placeholder={t('fields.email')}
                         className="input input-bordered w-full"
                         required
                       />
                       <label className="label">
-                        <span className="label-text-alt">We&apos;ll use this for important updates about your story</span>
+                        <span className="label-text-alt">{t('fields.emailHelp')}</span>
                       </label>
                     </div>
                     
                     {/* Mobile Phone Field */}
                     <div className="form-control">
                       <label className="label">
-                        <span className="label-text font-semibold">Mobile Phone</span>
+                        <span className="label-text font-semibold">{t('fields.mobile')}</span>
                       </label>                      <input
                         type="tel"
                         value={mobilePhone}
@@ -272,11 +262,11 @@ export default function Step1Page() {
                           setMobilePhone(e.target.value);
                           checkForChanges(displayName, email, e.target.value);
                         }}
-                        placeholder="Enter your mobile phone number"
+                        placeholder={t('fields.mobile')}
                         className="input input-bordered w-full"
                       />
                       <label className="label">
-                        <span className="label-text-alt">For urgent notifications or delivery updates (optional)</span>
+                        <span className="label-text-alt">{t('fields.mobileHelp')}</span>
                       </label>                    </div>                  </div>
                 </div>
               )}

--- a/src/app/[locale]/tell-your-story/step-2/page.tsx
+++ b/src/app/[locale]/tell-your-story/step-2/page.tsx
@@ -5,11 +5,12 @@ import Image from 'next/image';
 import StepNavigation from '../../../../components/StepNavigation';
 import { useState, useRef } from 'react';
 import { useRouter } from 'next/navigation';
-import { useLocale } from 'next-intl';
+import { useLocale, useTranslations } from 'next-intl';
 
 export default function Step2Page() {
   const router = useRouter();
   const locale = useLocale();
+  const t = useTranslations('StorySteps.step2');
   
   // Language options for story creation
   const languageOptions = [
@@ -423,11 +424,9 @@ export default function Step2Page() {
 
             {/* Step content */}
             <div className="card bg-base-100 shadow-xl">              <div className="card-body">
-                <h1 className="card-title text-3xl mb-6">Chapter 2 - The Story</h1>
+                <h1 className="card-title text-3xl mb-6">{t('heading')}</h1>
                 <div className="prose max-w-none mb-6">
-                  <p className="text-gray-600 text-lg">
-                    You can create your story by drawing it, recording it, or simply writing it down.
-                  </p>
+                  <p className="text-gray-600 text-lg">{t('intro')}</p>
                 </div>
 
                 {/* Language Selection */}
@@ -517,9 +516,7 @@ export default function Step2Page() {
                                 🖼️ Upload Image
                               </button>
                             </div>
-                            <p className="text-gray-600">
-                              Draw your story, take a photo of it, or upload an existing image that tells your tale.
-                            </p>
+                            <p className="text-gray-600">{t('imageHelp')}</p>
                           </div>
                         )}
 
@@ -612,9 +609,7 @@ export default function Step2Page() {
                                 📁 Upload Audio File
                               </button>
                             </div>
-                            <p className="text-gray-600">
-                              Record your story directly or upload an audio file. Perfect for those who prefer to speak their tales!
-                            </p>
+                            <p className="text-gray-600">{t('audioHelp')}</p>
                           </div>
                         )}
 
@@ -629,7 +624,7 @@ export default function Step2Page() {
                                 <div className="absolute inset-0 rounded-full border-4 border-red-500 animate-ping"></div>
                               </div>
                               <p className="text-lg font-semibold text-red-600">Recording...</p>
-                              <p className="text-gray-600">Tell your story! Speak clearly into your microphone.</p>
+                              <p className="text-gray-600">{t('recordingHelp')}</p>
                             </div>
                             <div className="flex gap-4 justify-center">
                               <button
@@ -699,9 +694,7 @@ export default function Step2Page() {
                   <div className="flex items-start space-x-3">
                     <div className="text-2xl">💡</div>
                     <div>
-                      <p className="text-blue-800 text-sm mt-1">
-                        If you&apos;ve written text or uploaded an image above, our AI will automatically extract characters, settings, and themes. Otherwise, the next steps will guide you through creating your story step by step.
-                      </p>
+                      <p className="text-blue-800 text-sm mt-1">{t('reassurance')}</p>
                     </div>
                   </div>
                 </div>
@@ -712,7 +705,7 @@ export default function Step2Page() {
                   prevHref="/tell-your-story/step-1"
                   nextDisabled={isCreatingStory}
                   onNext={handleNextStep}
-                  nextLabel={isCreatingStory ? "Processing with AI..." : (hasContent() ? "Next" : "Next Chapter")}
+                  nextLabel={isCreatingStory ? t('processing') : (hasContent() ? t('next') : t('nextChapter'))}
                 />
               </div>
             </div>

--- a/src/app/[locale]/tell-your-story/step-3/page.tsx
+++ b/src/app/[locale]/tell-your-story/step-3/page.tsx
@@ -5,10 +5,12 @@ import StepNavigation from '../../../../components/StepNavigation';
 import CharacterCard from '../../../../components/CharacterCard';
 import { useState, useEffect, useCallback } from 'react';
 import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import { getCurrentStoryId, setStep3Data, Character, hasValidStorySession } from '../../../../lib/story-session';
 
 export default function Step3Page() {
   const router = useRouter();
+  const t = useTranslations('StorySteps.step3');
   const [characters, setCharacters] = useState<Character[]>([]);
   const [availableCharacters, setAvailableCharacters] = useState<Character[]>([]);
   const [loading, setLoading] = useState(true);  const [showCreateForm, setShowCreateForm] = useState(false);
@@ -265,13 +267,10 @@ export default function Step3Page() {
             {/* Step content */}
             <div className="card bg-base-100 shadow-xl">
               <div className="card-body">
-                <h1 className="card-title text-3xl mb-6">Chapter 3 - The Characters</h1>
+                <h1 className="card-title text-3xl mb-6">{t('heading')}</h1>
                 
                 <div className="prose max-w-none mb-6">
-                  <p className="text-gray-600 text-lg">
-                    Who are the heroes, friends, and magical creatures in your story? 
-                    Create characters that will bring your adventure to life!
-                  </p>
+                  <p className="text-gray-600 text-lg">{t('intro')}</p>
                 </div>
 
                 {loading ? (
@@ -311,11 +310,11 @@ export default function Step3Page() {
                             className="btn btn-primary btn-lg"
                             onClick={() => setShowAddOptions(true)}
                           >
-                            ➕ Add Character
+                            {t('addCharacter')}
                           </button>
                         ) : (
                           <div className="space-y-4">
-                            <div className="text-lg font-semibold">Choose how to add a character:</div>
+                            <div className="text-lg font-semibold">{t('chooseMethod')}</div>
                             
                             {/* Create New Character Option */}
                             <button
@@ -325,7 +324,7 @@ export default function Step3Page() {
                                 setShowAddOptions(false);
                               }}
                             >
-                              ✨ Create New Character
+                              {t('createNew')}
                             </button>
                             
                             {/* Add Existing Character Option (only if available characters exist) */}
@@ -336,7 +335,7 @@ export default function Step3Page() {
                                 </div>
                                 <div className="dropdown dropdown-end w-full">
                                   <div tabIndex={0} role="button" className="btn btn-outline btn-lg w-full">
-                                    📚 Use Existing Character
+                                    {t('useExisting')}
                                   </div>
                                   <ul tabIndex={0} className="dropdown-content menu bg-base-100 rounded-box z-[1] w-full p-2 shadow-lg border max-h-60 overflow-y-auto">
                                     {availableCharacters.map((character) => (
@@ -371,7 +370,7 @@ export default function Step3Page() {
                               className="btn btn-ghost"
                               onClick={() => setShowAddOptions(false)}
                             >
-                              Cancel
+                              {t('cancel')}
                             </button>
                           </div>
                         )}
@@ -381,11 +380,9 @@ export default function Step3Page() {
                       <div className="bg-blue-50 border border-blue-200 rounded-lg p-6 text-center">
                         <div className="text-4xl mb-4">🎭</div>
                         <h3 className="text-xl font-semibold text-blue-800 mb-2">
-                          Ready to meet your characters?
+                          {t('readyTitle')}
                         </h3>
-                        <p className="text-blue-600">                          Every great story needs amazing characters! Click &quot;Add Character&quot; to create 
-                          new heroes or add existing characters from your library to this story.
-                        </p>
+                        <p className="text-blue-600">{t('readyDescription')}</p>
                       </div>
                     )}
 
@@ -395,12 +392,8 @@ export default function Step3Page() {
                         <div className="flex items-start space-x-3">
                           <div className="text-2xl">💡</div>
                           <div>
-                            <p className="text-green-800 font-medium">
-                              Great work! You&apos;ve created {characters.length} character{characters.length === 1 ? '' : 's'}.
-                            </p>
-                            <p className="text-green-600 text-sm mt-1">
-                              You can always add more characters later or continue to the next chapter to develop your story further.
-                            </p>
+                            <p className="text-green-800 font-medium">{t('greatWork', {count: characters.length})}</p>
+                            <p className="text-green-600 text-sm mt-1">{t('youCanAlways')}</p>
                           </div>
                         </div>
                       </div>
@@ -415,7 +408,7 @@ export default function Step3Page() {
                   prevHref={null} // Disabled - don't allow going back to step 2
                   nextDisabled={isNavigating}
                   onNext={handleNextStep}
-                  nextLabel={isNavigating ? "Continuing..." : "Next Chapter"}
+                  nextLabel={isNavigating ? t('continuing') : t('nextChapter')}
                 />
               </div>
             </div>

--- a/src/app/[locale]/tell-your-story/step-4/page.tsx
+++ b/src/app/[locale]/tell-your-story/step-4/page.tsx
@@ -4,6 +4,7 @@ import { SignedIn, SignedOut, RedirectToSignIn } from '@clerk/nextjs';
 import StepNavigation from '../../../../components/StepNavigation';
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import { getCurrentStoryId, hasValidStorySession } from '../../../../lib/story-session';
 import { 
   TargetAudience, 
@@ -29,7 +30,9 @@ interface StoryData {
 }
 
 export default function Step4Page() {
-  const router = useRouter();  const [loading, setLoading] = useState(true);
+  const router = useRouter();
+  const t = useTranslations('StorySteps.step4');
+  const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [currentStoryId, setCurrentStoryId] = useState<string | null>(null);
@@ -201,20 +204,17 @@ export default function Step4Page() {
             {/* Step content */}
             <div className="card bg-base-100 shadow-xl">
               <div className="card-body">
-                <h1 className="card-title text-3xl mb-6">Chapter 4 - The Plot</h1>
+                <h1 className="card-title text-3xl mb-6">{t('heading')}</h1>
                 
                 {loading ? (
                   <div className="text-center py-12">
                     <span className="loading loading-spinner loading-lg"></span>
-                    <p className="text-lg text-gray-600 mt-4">Loading your story details...</p>
+                    <p className="text-lg text-gray-600 mt-4">{t('saving')}</p>
                   </div>
                 ) : (
                   <div className="space-y-6">
                     <div className="prose max-w-none mb-6">
-                      <p className="text-gray-600">
-                        Now let&apos;s define the core elements of your story. Tell us about the world you want to create, 
-                        who you&apos;re writing for, and how you envision your story looking.
-                      </p>
+                      <p className="text-gray-600">{t('intro')}</p>
                     </div>
 
                     {error && (
@@ -229,40 +229,40 @@ export default function Step4Page() {
                       {/* Title Field */}
                       <div className="form-control md:col-span-2">
                         <label className="label">
-                          <span className="label-text font-semibold">Book Title *</span>
+                          <span className="label-text font-semibold">{t('fields.title')}</span>
                         </label>
                         <input
                           type="text"
                           value={title}
                           onChange={(e) => setTitle(e.target.value)}
-                          placeholder="Enter your book title"
+                          placeholder={t('fields.title')}
                           className="input input-bordered w-full"
                           required
                         />
                         <label className="label">
-                          <span className="label-text-alt">Choose a captivating title for your story</span>
+                          <span className="label-text-alt">{t('fields.titleHelp')}</span>
                         </label>
                       </div>
 
                       {/* Place Field */}
                       <div className="form-control">
                         <label className="label">
-                          <span className="label-text font-semibold">Setting/Place</span>
+                          <span className="label-text font-semibold">{t('fields.place')}</span>
                         </label>
                         <input
                           type="text"
                           value={place}
                           onChange={(e) => setPlace(e.target.value)}
-                          placeholder="e.g., Enchanted Forest, Modern City, Space Station..."
+                          placeholder={t('fields.place')}
                           className="input input-bordered w-full"
                         />
                         <label className="label">
-                          <span className="label-text-alt">Where does your story take place? (real or imaginary)</span>
+                          <span className="label-text-alt">{t('fields.placeHelp')}</span>
                         </label>
                       </div>                      {/* Target Audience Field */}
                       <div className="form-control">
                         <label className="label">
-                          <span className="label-text font-semibold">Target Audience</span>
+                          <span className="label-text font-semibold">{t('fields.audience')}</span>
                         </label>
                         <select
                           value={targetAudience}
@@ -276,14 +276,14 @@ export default function Step4Page() {
                           ))}
                         </select>
                         <label className="label">
-                          <span className="label-text-alt">Who is this story written for?</span>
+                          <span className="label-text-alt">{t('fields.audienceHelp')}</span>
                         </label>
                       </div>
 
                       {/* Novel Style Field */}
                       <div className="form-control">
                         <label className="label">
-                          <span className="label-text font-semibold">Novel Style</span>
+                          <span className="label-text font-semibold">{t('fields.novelStyle')}</span>
                         </label>
                         <select
                           value={novelStyle}
@@ -297,14 +297,14 @@ export default function Step4Page() {
                           ))}
                         </select>
                         <label className="label">
-                          <span className="label-text-alt">What genre/style should your story be?</span>
+                          <span className="label-text-alt">{t('fields.novelStyleHelp')}</span>
                         </label>
                       </div>
 
                       {/* Graphic Style Field */}
                       <div className="form-control md:col-span-2">
                         <label className="label">
-                          <span className="label-text font-semibold">Graphic Style</span>
+                          <span className="label-text font-semibold">{t('fields.graphicStyle')}</span>
                         </label>
                         <select
                           value={graphicalStyle}
@@ -318,7 +318,7 @@ export default function Step4Page() {
                           ))}
                         </select>
                         <label className="label">
-                          <span className="label-text-alt">Choose the artistic style for your story&apos;s illustrations</span>
+                          <span className="label-text-alt">{t('fields.graphicStyleHelp')}</span>
                         </label>
                       </div>
                     </div>
@@ -326,7 +326,7 @@ export default function Step4Page() {
                     {/* Story Outline Field */}
                     <div className="form-control">
                       <label className="label">
-                        <span className="label-text font-semibold">Story Outline</span>
+                        <span className="label-text font-semibold">{t('fields.outline')}</span>
                       </label>
                       <textarea
                         value={plotDescription}
@@ -336,25 +336,25 @@ export default function Step4Page() {
                         rows={6}
                       />
                       <label className="label">
-                        <span className="label-text-alt">Describe your story&apos;s plot, characters, and key events</span>
+                        <span className="label-text-alt">{t('fields.outlineHelp')}</span>
                       </label>
                     </div>
 
                     {/* Additional Requests Field */}
                     <div className="form-control">
                       <label className="label">
-                        <span className="label-text font-semibold">Additional Requests</span>
-                        <span className="label-text-alt">Optional</span>
+                        <span className="label-text font-semibold">{t('fields.additional')}</span>
+                        <span className="label-text-alt">{t('fields.additional')}</span>
                       </label>
                       <textarea
                         value={additionalRequests}
                         onChange={(e) => setAdditionalRequests(e.target.value)}
-                        placeholder="Mention any specific products, companies, or details to include..."
+                        placeholder={t('fields.additional')}
                         className="textarea textarea-bordered h-24 w-full"
                         rows={4}
                       />
                       <label className="label">
-                        <span className="label-text-alt">Any special requests or specific elements you want included</span>
+                        <span className="label-text-alt">{t('fields.additionalHelp')}</span>
                       </label>
                     </div>                  </div>
                 )}
@@ -366,7 +366,7 @@ export default function Step4Page() {
                   prevHref="/tell-your-story/step-3"
                   onNext={handleNext}
                   nextDisabled={saving}
-                  nextLabel={saving ? "Saving..." : "Next Chapter"}
+                  nextLabel={saving ? t('saving') : t('nextChapter')}
                 />
               </div>
             </div>

--- a/src/app/[locale]/tell-your-story/step-5/page.tsx
+++ b/src/app/[locale]/tell-your-story/step-5/page.tsx
@@ -4,6 +4,7 @@ import { SignedIn, SignedOut, RedirectToSignIn } from '@clerk/nextjs';
 import StepNavigation from '../../../../components/StepNavigation';
 import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import { getCurrentStoryId, hasValidStorySession } from '../../../../lib/story-session';
 
 interface StoryData {
@@ -52,6 +53,7 @@ interface StoryUpdateData {
 
 export default function Step5Page() {
   const router = useRouter();
+  const t = useTranslations('StorySteps.step5');
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -360,17 +362,15 @@ export default function Step5Page() {
             {/* Step content */}
             <div className="card bg-base-100 shadow-xl">
               <div className="card-body">
-                <h1 className="card-title text-3xl mb-6">Chapter 5 - The Gift</h1>
+                <h1 className="card-title text-3xl mb-6">{t('heading')}</h1>
                   {loading || !pricingData ? (
                   <div className="text-center py-12">
                     <span className="loading loading-spinner loading-lg"></span>
-                    <p className="text-lg text-gray-600 mt-4">Loading your story details and pricing...</p>
+                    <p className="text-lg text-gray-600 mt-4">{t('creating')}</p>
                   </div>
                 ) : (<div className="space-y-6">
                     <div className="prose max-w-none mb-6">
-                      <p className="text-gray-600">
-                        Choose how you&apos;d like to receive your story. You can select multiple delivery formats to enjoy your story in different ways.
-                      </p>
+                      <p className="text-gray-600">{t('intro')}</p>
                     </div>
 
                     {error && (
@@ -385,7 +385,7 @@ export default function Step5Page() {
                     {/* Delivery Options */}
                     {pricingData && (
                       <div className="space-y-4">
-                        <h2 className="text-xl font-semibold mb-4">Delivery Options</h2>
+                        <h2 className="text-xl font-semibold mb-4">{t('deliveryOptions')}</h2>
                         
                         {/* Digital (ebook) - Mandatory */}
                         <div className="card bg-base-200">
@@ -620,7 +620,7 @@ export default function Step5Page() {
                             onClick={handleBuyMoreCredits}
                             className="btn btn-warning btn-lg"
                           >
-                            Buy More Credits
+                            {t('buyMoreCredits')}
                           </button>
                         </div>
                       )}
@@ -634,7 +634,7 @@ export default function Step5Page() {
                   prevHref="/tell-your-story/step-4"
                   onNext={handleNext}
                   nextDisabled={saving || hasInsufficientCredits()}
-                  nextLabel={saving ? "Creating..." : hasInsufficientCredits() ? "Insufficient Credits" : "Create story"}
+                  nextLabel={saving ? t('creating') : hasInsufficientCredits() ? t('insufficientCredits') : t('createStory')}
                 />
               </div>
             </div>
@@ -643,16 +643,16 @@ export default function Step5Page() {
         {showBuyCreditsModal && (
           <div className="modal modal-open">
             <div className="modal-box">
-              <h3 className="font-bold text-lg">Buy More Credits</h3>
+              <h3 className="font-bold text-lg">{t('buyMoreCredits')}</h3>
               <p className="py-4">
-                Credit purchasing functionality is coming soon! Stay tuned for updates.
+                {t('buyMoreCreditsInfo')}
               </p>
               <div className="modal-action">
                 <button 
                   className="btn" 
                   onClick={() => setShowBuyCreditsModal(false)}
                 >
-                  Close
+                  {t('close')}
                 </button>
               </div>
             </div>

--- a/src/app/portaldegestao/users/[id]/page.tsx
+++ b/src/app/portaldegestao/users/[id]/page.tsx
@@ -6,7 +6,7 @@ import { useRouter } from 'next/navigation';
 import { useParams } from 'next/navigation';
 import AdminHeader from '../../../../components/AdminHeader';
 import AdminFooter from '../../../../components/AdminFooter';
-import { getNovelStyleLabelSafe, getTargetAudienceLabelSafe, getGraphicalStyleLabelSafe } from '@/lib/story-enum-mapping';
+import { getNovelStyleLabelSafe, getTargetAudienceLabelSafe } from '@/lib/story-enum-mapping';
 
 interface CreditHistoryEntry {
   id: string;

--- a/src/components/StepNavigation.tsx
+++ b/src/components/StepNavigation.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 
 interface StepNavigationProps {
   currentStep: number;
@@ -23,10 +24,14 @@ const StepNavigation = ({
   onNext,
   onPrev,
   nextDisabled = false,
-  nextLabel = 'Next', // Changed default
-  prevLabel = 'Prev'  // Changed default
+  nextLabel,
+  prevLabel
 }: StepNavigationProps) => {
   const router = useRouter();
+  const t = useTranslations('StepNavigation');
+
+  const resolvedNextLabel = nextLabel ?? t('next');
+  const resolvedPrevLabel = prevLabel ?? t('prev');
   const handleNext = async () => {
     if (onNext) {
       const result = await onNext();
@@ -59,7 +64,7 @@ const StepNavigation = ({
             <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 mr-1 md:mr-2" fill="none" viewBox="0 0 24 24" stroke="currentColor"> {/* Responsive icon margin */}
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />
             </svg>
-            {prevLabel}
+            {resolvedPrevLabel}
           </Link>
         ) : (
           <div></div> // Empty div to maintain flex layout
@@ -76,7 +81,7 @@ const StepNavigation = ({
             disabled={nextDisabled}
             className={`btn btn-primary btn-md md:btn-lg ${nextDisabled ? 'btn-disabled' : ''}`} // Responsive button size
           >
-            {currentStep === totalSteps - 1 ? 'Finish' : nextLabel} {/* Shortened "Finish Story" */}
+            {currentStep === totalSteps - 1 ? t('finish') : resolvedNextLabel} {/* Shortened "Finish Story" */}
             <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 ml-1 md:ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor"> {/* Responsive icon margin */}
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
             </svg>
@@ -87,7 +92,7 @@ const StepNavigation = ({
             className={`btn btn-primary btn-md md:btn-lg ${nextDisabled ? 'btn-disabled' : ''}`} // Responsive button size
             onClick={handleNext}
           >
-            {currentStep === totalSteps - 1 ? 'Finish' : nextLabel} {/* Shortened "Finish Story" */}
+            {currentStep === totalSteps - 1 ? t('finish') : resolvedNextLabel} {/* Shortened "Finish Story" */}
             <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 ml-1 md:ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor"> {/* Responsive icon margin */}
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
             </svg>
@@ -98,7 +103,7 @@ const StepNavigation = ({
             disabled={nextDisabled}
             className={`btn btn-primary btn-md md:btn-lg ${nextDisabled ? 'btn-disabled' : ''}`} // Responsive button size
           >
-            {currentStep === totalSteps - 1 ? 'Finish' : nextLabel} {/* Shortened "Finish Story" */}
+            {currentStep === totalSteps - 1 ? t('finish') : resolvedNextLabel} {/* Shortened "Finish Story" */}
             <svg xmlns="http://www.w3.org/2000/svg" className="h-5 w-5 ml-1 md:ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor"> {/* Responsive icon margin */}
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
             </svg>

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -9,11 +9,12 @@ export default getRequestConfig(async ({requestLocale}) => {
     locale = routing.defaultLocale;
   }
   // Load and merge messages from different domain files
-  const [commonMessages, publicPagesMessages, privacyPolicyMessages, pricingMessages] = await Promise.all([
+  const [commonMessages, publicPagesMessages, privacyPolicyMessages, pricingMessages, storyStepsMessages] = await Promise.all([
     import(`../messages/${locale}/common.json`).then(module => module.default),
     import(`../messages/${locale}/publicPages.json`).then(module => module.default),
     import(`../messages/${locale}/privacy-policy.json`).then(module => module.default),
-    import(`../messages/${locale}/pricing.json`).then(module => module.default)
+    import(`../messages/${locale}/pricing.json`).then(module => module.default),
+    import(`../messages/${locale}/storySteps.json`).then(module => module.default)
   ]);
 
   return {
@@ -22,7 +23,8 @@ export default getRequestConfig(async ({requestLocale}) => {
       ...commonMessages,
       ...publicPagesMessages,
       ...privacyPolicyMessages,
-      ...pricingMessages
+      ...pricingMessages,
+      ...storyStepsMessages
     }
   };
 });

--- a/src/messages/en-US/common.json
+++ b/src/messages/en-US/common.json
@@ -40,5 +40,10 @@
       "alreadyRegistered": "Wow, you are really eager to experience Mythoria. Rest assured we will notify you when we launch!"
     },
     "privacy": "We respect your privacy. No spam, just launch notifications."
+  },
+  "StepNavigation": {
+    "next": "Next",
+    "prev": "Prev",
+    "finish": "Finish"
   }
 }

--- a/src/messages/en-US/storySteps.json
+++ b/src/messages/en-US/storySteps.json
@@ -1,0 +1,89 @@
+{
+  "StorySteps": {
+    "step1": {
+      "unauthenticated": {
+        "title": "Oops! Looks like you're trying to sneak into the author's lounge!",
+        "description": "While we appreciate your enthusiasm for storytelling, you'll need to sign in first. Don't worry, it's easier than convincing a dragon to share its treasure! 🐉",
+        "signIn": "🔐 Sign In to Start Your Adventure",
+        "signUp": "✨ Create Your Author Account",
+        "note": "Once you're signed in, you'll be ready to create magical stories that would make even Merlin jealous! 🧙‍♂️"
+      },
+      "heading": "Chapter 1 - The Author",
+      "intro": "Welcome, storyteller! Before we dive into your magical adventure, let's make sure we have your correct information. This helps us personalize your experience and keep you updated on your story's progress.",
+      "fields": {
+        "fullName": "Full Name *",
+        "fullNameHelp": "This is how you'll be credited as the author",
+        "email": "Email Address *",
+        "emailHelp": "We'll use this for important updates about your story",
+        "mobile": "Mobile Phone",
+        "mobileHelp": "For urgent notifications or delivery updates (optional)"
+      },
+      "messages": {
+        "loadingProfile": "Loading your author profile...",
+        "required": "Please fill in all required fields",
+        "saveFailed": "Failed to save profile. Please try again.",
+        "fetchFailed": "Failed to fetch user data",
+        "loadFailed": "Failed to load user information. Please try again."
+      }
+    },
+    "step2": {
+      "heading": "Chapter 2 - The Story",
+      "intro": "You can create your story by drawing it, recording it, or simply writing it down.",
+      "imageHelp": "Draw your story, take a photo of it, or upload an existing image that tells your tale.",
+      "audioHelp": "Record your story directly or upload an audio file. Perfect for those who prefer to speak their tales!",
+      "recordingHelp": "Tell your story! Speak clearly into your microphone.",
+      "reassurance": "If you've written text or uploaded an image above, our AI will automatically extract characters, settings, and themes. Otherwise, the next steps will guide you through creating your story step by step.",
+      "processing": "Processing with AI...",
+      "nextChapter": "Next Chapter",
+      "next": "Next"
+    },
+    "step3": {
+      "heading": "Chapter 3 - The Characters",
+      "intro": "Who are the heroes, friends, and magical creatures in your story? Create characters that will bring your adventure to life!",
+      "addCharacter": "➕ Add Character",
+      "chooseMethod": "Choose how to add a character:",
+      "createNew": "✨ Create New Character",
+      "useExisting": "📚 Use Existing Character",
+      "cancel": "Cancel",
+      "readyTitle": "Ready to meet your characters?",
+      "readyDescription": "Every great story needs amazing characters! Click \"Add Character\" to create new heroes or add existing characters from your library to this story.",
+      "greatWork": "Great work! You've created {count} character{count === 1 ? '' : 's' }.",
+      "youCanAlways": "You can always add more characters later or continue to the next chapter to develop your story further.",
+      "continuing": "Continuing...",
+      "nextChapter": "Next Chapter"
+    },
+    "step4": {
+      "heading": "Chapter 4 - The Plot",
+      "intro": "Now let's define the core elements of your story. Tell us about the world you want to create, who you're writing for, and how you envision your story looking.",
+      "fields": {
+        "title": "Book Title *",
+        "titleHelp": "Choose a captivating title for your story",
+        "place": "Setting/Place",
+        "placeHelp": "Where does your story take place? (real or imaginary)",
+        "audience": "Target Audience",
+        "audienceHelp": "Who is this story written for?",
+        "novelStyle": "Novel Style",
+        "novelStyleHelp": "What genre/style should your story be?",
+        "graphicStyle": "Graphic Style",
+        "graphicStyleHelp": "Choose the artistic style for your story's illustrations",
+        "outline": "Story Outline",
+        "outlineHelp": "Describe your story's plot, characters, and key events",
+        "additional": "Additional Requests",
+        "additionalHelp": "Any special requests or specific elements you want included"
+      },
+      "saving": "Saving...",
+      "nextChapter": "Next Chapter"
+    },
+    "step5": {
+      "heading": "Chapter 5 - The Gift",
+      "intro": "Choose how you'd like to receive your story. You can select multiple delivery formats to enjoy your story in different ways.",
+      "deliveryOptions": "Delivery Options",
+      "creating": "Creating...",
+      "insufficientCredits": "Insufficient Credits",
+      "createStory": "Create story",
+      "buyMoreCredits": "Buy More Credits",
+      "buyMoreCreditsInfo": "Credit purchasing functionality is coming soon! Stay tuned for updates.",
+      "close": "Close"
+    }
+  }
+}

--- a/src/messages/pt-PT/common.json
+++ b/src/messages/pt-PT/common.json
@@ -40,5 +40,10 @@
       "alreadyRegistered": "Uau, está mesmo ansioso para experimentar a Mythoria. Fique descansado que iremos notificá-lo quando lançarmos!"
     },
     "privacy": "Respeitamos a sua privacidade. Sem spam, apenas notificações de lançamento."
+  },
+  "StepNavigation": {
+    "next": "Seguinte",
+    "prev": "Anterior",
+    "finish": "Concluir"
   }
 }

--- a/src/messages/pt-PT/storySteps.json
+++ b/src/messages/pt-PT/storySteps.json
@@ -1,0 +1,89 @@
+{
+  "StorySteps": {
+    "step1": {
+      "unauthenticated": {
+        "title": "Ops! Parece que estás a tentar entrar no lounge dos autores!",
+        "description": "Embora apreciemos o teu entusiasmo pela narração, tens de iniciar sessão primeiro. Não te preocupes, é mais fácil do que convencer um dragão a partilhar o seu tesouro! 🐉",
+        "signIn": "🔐 Iniciar Sessão para Começar a Aventura",
+        "signUp": "✨ Criar Conta de Autor",
+        "note": "Depois de iniciares sessão, estarás pronto para criar histórias mágicas que fariam inveja ao próprio Merlin! 🧙‍♂️"
+      },
+      "heading": "Capítulo 1 - O Autor",
+      "intro": "Bem-vindo, contador de histórias! Antes de mergulharmos na tua aventura mágica, vamos garantir que temos a tua informação correta. Isto ajuda-nos a personalizar a tua experiência e a manter-te atualizado sobre o progresso da tua história.",
+      "fields": {
+        "fullName": "Nome Completo *",
+        "fullNameHelp": "É assim que serás creditado como autor",
+        "email": "Endereço de Email *",
+        "emailHelp": "Usaremos isto para atualizações importantes sobre a tua história",
+        "mobile": "Telemóvel",
+        "mobileHelp": "Para notificações urgentes ou atualizações de entrega (opcional)"
+      },
+      "messages": {
+        "loadingProfile": "A carregar o teu perfil de autor...",
+        "required": "Por favor, preenche todos os campos obrigatórios",
+        "saveFailed": "Falha ao guardar o perfil. Tenta novamente.",
+        "fetchFailed": "Falha ao obter dados do utilizador",
+        "loadFailed": "Falha ao carregar a informação do utilizador. Tenta novamente."
+      }
+    },
+    "step2": {
+      "heading": "Capítulo 2 - A História",
+      "intro": "Podes criar a tua história desenhando-a, gravando-a ou simplesmente escrevendo-a.",
+      "imageHelp": "Desenha a tua história, tira-lhe uma foto ou carrega uma imagem existente que a represente.",
+      "audioHelp": "Grava a tua história diretamente ou carrega um ficheiro de áudio. Perfeito para quem prefere contar as suas histórias!",
+      "recordingHelp": "Conta a tua história! Fala claramente para o microfone.",
+      "reassurance": "Se escreveste texto ou carregaste uma imagem acima, a nossa IA irá extrair automaticamente personagens, cenários e temas. Caso contrário, os próximos passos vão guiar-te na criação da tua história passo a passo.",
+      "processing": "A processar com IA...",
+      "nextChapter": "Próximo Capítulo",
+      "next": "Seguinte"
+    },
+    "step3": {
+      "heading": "Capítulo 3 - As Personagens",
+      "intro": "Quem são os heróis, amigos e criaturas mágicas da tua história? Cria personagens que darão vida à tua aventura!",
+      "addCharacter": "➕ Adicionar Personagem",
+      "chooseMethod": "Escolhe como adicionar uma personagem:",
+      "createNew": "✨ Criar Nova Personagem",
+      "useExisting": "📚 Usar Personagem Existente",
+      "cancel": "Cancelar",
+      "readyTitle": "Preparado para conhecer as tuas personagens?",
+      "readyDescription": "Toda a grande história precisa de personagens incríveis! Clica em \"Adicionar Personagem\" para criar novos heróis ou adicionar personagens existentes da tua biblioteca a esta história.",
+      "greatWork": "Bom trabalho! Criaste {count} personagem{count === 1 ? '' : 's' }.",
+      "youCanAlways": "Podes sempre adicionar mais personagens mais tarde ou avançar para o próximo capítulo para desenvolver ainda mais a tua história.",
+      "continuing": "A continuar...",
+      "nextChapter": "Próximo Capítulo"
+    },
+    "step4": {
+      "heading": "Capítulo 4 - O Enredo",
+      "intro": "Vamos agora definir os elementos centrais da tua história. Fala-nos do mundo que queres criar, para quem escreves e como imaginas a aparência da tua história.",
+      "fields": {
+        "title": "Título do Livro *",
+        "titleHelp": "Escolhe um título cativante para a tua história",
+        "place": "Cenário/Local",
+        "placeHelp": "Onde decorre a tua história? (real ou imaginário)",
+        "audience": "Público-Alvo",
+        "audienceHelp": "Para quem é escrita esta história?",
+        "novelStyle": "Estilo do Romance",
+        "novelStyleHelp": "Que género/estilo deve ter a tua história?",
+        "graphicStyle": "Estilo Gráfico",
+        "graphicStyleHelp": "Escolhe o estilo artístico das ilustrações da tua história",
+        "outline": "Esboço da História",
+        "outlineHelp": "Descreve o enredo, as personagens e os acontecimentos principais da tua história",
+        "additional": "Pedidos Adicionais",
+        "additionalHelp": "Algum pedido especial ou elementos específicos que queiras incluir"
+      },
+      "saving": "A guardar...",
+      "nextChapter": "Próximo Capítulo"
+    },
+    "step5": {
+      "heading": "Capítulo 5 - O Presente",
+      "intro": "Escolhe como gostarias de receber a tua história. Podes selecionar vários formatos de entrega para desfrutares dela de diferentes maneiras.",
+      "deliveryOptions": "Opções de Entrega",
+      "creating": "A criar...",
+      "insufficientCredits": "Créditos Insuficientes",
+      "createStory": "Criar história",
+      "buyMoreCredits": "Comprar Mais Créditos",
+      "buyMoreCreditsInfo": "A funcionalidade de compra de créditos chegará em breve! Fica atento às novidades.",
+      "close": "Fechar"
+    }
+  }
+}

--- a/src/types/story-enums.ts
+++ b/src/types/story-enums.ts
@@ -116,13 +116,13 @@ export const getGraphicalStyleLabel = (value: GraphicalStyle): string =>
 
 // Helper functions to find enum value from label (useful for backward compatibility)
 export const findTargetAudienceByLabel = (label: string): TargetAudience | undefined => {
-  return Object.entries(TargetAudienceLabels).find(([_, l]) => l === label)?.[0] as TargetAudience;
+  return Object.entries(TargetAudienceLabels).find(([, l]) => l === label)?.[0] as TargetAudience;
 };
 
 export const findNovelStyleByLabel = (label: string): NovelStyle | undefined => {
-  return Object.entries(NovelStyleLabels).find(([_, l]) => l === label)?.[0] as NovelStyle;
+  return Object.entries(NovelStyleLabels).find(([, l]) => l === label)?.[0] as NovelStyle;
 };
 
 export const findGraphicalStyleByLabel = (label: string): GraphicalStyle | undefined => {
-  return Object.entries(GraphicalStyleLabels).find(([_, l]) => l === label)?.[0] as GraphicalStyle;
+  return Object.entries(GraphicalStyleLabels).find(([, l]) => l === label)?.[0] as GraphicalStyle;
 };


### PR DESCRIPTION
## Summary
- add new translation files for story creation steps
- load story step messages in i18n config
- internationalize StepNavigation component
- update step pages 1-5 to use translated strings
- extend common translations for StepNavigation
- fix lint issues in admin pages and enums

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684f1686e5a083289c193c62c38258c4