### PR TITLE
Organize documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,4 @@ npm install
 # (Further setup steps for database, .env, etc.)
 npm run dev
 ```
+\nFor full documentation see [docs/README.md](docs/README.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,13 @@
+# Mythoria Documentation
+
+This documentation provides an overview of the Mythoria web application, its deployment and operational practices.
+
+## Index
+
+1. [Product & Features](product-features.md)
+2. [Architecture Overview](architecture-overview.md)
+3. [Infrastructure & DevOps](infrastructure-devops.md)
+4. [Deployment Guide](deployment/README.md)
+5. [Database](database.md)
+6. [API & Integration](api-and-integration.md)
+7. [Security & Compliance](security-compliance.md)

--- a/docs/api-and-integration.md
+++ b/docs/api-and-integration.md
@@ -1,0 +1,12 @@
+# API & Integration
+
+Mythoria exposes a small set of Next.js API routes. External services are used for analytics and authentication.
+
+## External Services
+
+- **NextAuth.js** – Handles user authentication and session management.
+- **Google Analytics 4** – Captures page views and user interactions.
+
+## Internal API Example
+
+`GET /api/hello` – sample endpoint returning a greeting message.

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -1,0 +1,15 @@
+# Architecture Overview
+
+The application is built with Next.js using the App Router. It serves both the frontend React components and backend API routes. Data is stored in a PostgreSQL database accessed through Drizzle ORM, while authentication is handled with NextAuth.js.
+
+```mermaid
+flowchart TD
+    A[User] -->|HTTPS| B(Mythoria Web App)
+    B --> C{Next.js Server}
+    C --> D[API Routes]
+    C --> E[React UI]
+    D --> F[(PostgreSQL)]
+    C --> G[Authentication\nNextAuth]
+```
+
+The system is packaged as a Docker container and deployed to Google Cloud Run.

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,26 @@
+# Database
+
+Mythoria uses PostgreSQL accessed through Drizzle ORM. The following diagram illustrates the logical data model.
+
+```mermaid
+erDiagram
+    users {
+        int id PK
+        text email
+        text name
+    }
+    stories {
+        int id PK
+        int user_id FK
+        text title
+        text content
+    }
+    users ||--o{ stories : has
+```
+
+### Table Definitions
+
+- **users** – registered accounts with a unique email.
+- **stories** – generated story records linked to the creating user.
+
+Indexes and constraints are defined through Drizzle migrations.

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -1,0 +1,35 @@
+# Deployment
+
+This section describes how to deploy the Mythoria web application to Google Cloud Run, monitor its health and perform rollbacks.
+
+## Quick Deployment
+
+```bash
+./scripts/deploy.sh
+```
+
+For Windows PowerShell use `./scripts/deploy.ps1`.
+
+## Manual Steps
+
+1. Build the application:
+   ```bash
+   npm run build
+   ```
+2. Submit the build to Google Cloud:
+   ```bash
+   gcloud builds submit --config cloudbuild.yaml
+   ```
+3. Deploy to Cloud Run using the generated image.
+4. Check the service health:
+   ```bash
+   curl https://mythoria.pt/api/health
+   ```
+
+Environment variables are stored in `.env.production.yaml` and loaded at runtime by Cloud Run.
+
+### Rollback & Recovery
+
+- Use Cloud Run revisions to roll back to a previous container image.
+- Monitor logs via Cloud Logging to detect failures.
+- Health checks are exposed at `/api/health`.

--- a/docs/infrastructure-devops.md
+++ b/docs/infrastructure-devops.md
@@ -1,0 +1,23 @@
+# Infrastructure & DevOps
+
+Mythoria runs on Google Cloud. The codebase is built into a container image using Cloud Build and deployed to Cloud Run. Secrets are provided via environment variables stored in `.env.production.yaml`.
+
+## Google Cloud Projects
+
+| Codename | Service | Purpose |
+|----------|---------|---------|
+| `mythoria-prod` | Cloud Run | Hosts the production container |
+| `mythoria-build` | Cloud Build | Builds Docker images |
+| `mythoria-storage` | Cloud Storage | Stores static assets and deployment artifacts |
+
+## CI/CD Pipeline
+
+1. **Build** – `gcloud builds submit` builds the Docker image using `cloudbuild.yaml`.
+2. **Deploy** – Cloud Run receives the new image and rolls out the latest revision.
+3. **Secrets** – Environment variables are stored in Secret Manager and mounted via `.env.production.yaml`.
+
+## Cost & Scaling
+
+- Cloud Run scales automatically based on HTTP requests.
+- Container concurrency and memory limits can be adjusted in the service settings.
+- Billing is tied to the `mythoria-prod` project quota.

--- a/docs/product-features.md
+++ b/docs/product-features.md
@@ -1,0 +1,17 @@
+# Product & Features
+
+Mythoria is an AI‑powered storytelling platform that allows users to generate personalized adventures. The application targets families, individuals and companies that want to transform their ideas into custom books.
+
+## Key Features
+
+- **Personalized Story Creation** – Craft stories featuring yourself or your loved ones.
+- **AI‑Powered Narratives** – Uses artificial intelligence to generate unique content.
+- **Multiple Audiences** – Kids, adults and corporate customers can all create their own adventures.
+- **Easy Customization**
+  1. Choose characters.
+  2. Describe passions and superpowers.
+  3. Optionally upload photos or provide descriptions.
+  4. Pick from many story settings (space missions, enchanted castles, etc.).
+  5. Add unique details including products, services or family traditions.
+  6. Select delivery format – hardcover book, digital ebook or audiobook.
+- **Focus on Imagination and Reading** – Encourages creativity and a passion for reading.

--- a/docs/security-compliance.md
+++ b/docs/security-compliance.md
@@ -1,0 +1,15 @@
+# Security & Compliance
+
+Data is protected in transit using HTTPS and at rest through Google Cloud managed encryption. Environment variables and secrets are stored in Secret Manager and loaded at runtime.
+
+```mermaid
+flowchart LR
+    Secrets(Secret Manager) --> App[Cloud Run Service]
+    App --> DB[(PostgreSQL)]
+```
+
+## Threat Model
+
+- **Data Exposure** – Mitigated via TLS and least‑privilege access.
+- **Secret Leakage** – Secrets are never stored in the repository and are rotated periodically in Secret Manager.
+- **Audit Trails** – Cloud Logging records application and access logs for compliance reviews.


### PR DESCRIPTION
## Summary
- organize docs with a new index and structure
- describe product features, architecture, DevOps, database, API and security
- add deployment instructions
- point main README to documentation

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6852c323d1348328b9e3172e0f406c3b