### PR TITLE
Add ContactUs page

### DIFF
--- a/src/app/[locale]/contactUs/page.tsx
+++ b/src/app/[locale]/contactUs/page.tsx
@@ -1,0 +1,101 @@
+import { getTranslations, setRequestLocale } from 'next-intl/server';
+
+interface ContactUsPageProps {
+  params: Promise<{ locale: string }>;
+}
+
+export default async function ContactUsPage({ params }: ContactUsPageProps) {
+  const { locale } = await params;
+  setRequestLocale(locale);
+
+  const t = await getTranslations('ContactUsPage');
+
+  return (
+    <div className="min-h-screen bg-base-100">
+      <div className="container mx-auto px-4 py-12 max-w-3xl space-y-12">
+        <section>
+          <h1 className="text-4xl font-bold mb-4">{t('title')}</h1>
+          <p className="mb-6">{t('intro')}</p>
+          <h2 className="text-2xl font-semibold mb-2">{t('scrollTitle')}</h2>
+          <p className="mb-4">{t('scrollIntro')}</p>
+          <ul className="list-disc list-inside space-y-1 mb-8">
+            <li>{t('categories.featureIdeas')}</li>
+            <li>{t('categories.reportBug')}</li>
+            <li>{t('categories.troubles')}</li>
+            <li>{t('categories.delivery')}</li>
+            <li>{t('categories.credits')}</li>
+            <li>{t('categories.general')}</li>
+          </ul>
+          <h2 className="text-2xl font-semibold mb-4">{t('form.title')}</h2>
+          <form className="space-y-4">
+            <div className="form-control">
+              <label className="label" htmlFor="name">
+                <span className="label-text">{t('form.name')}</span>
+              </label>
+              <input
+                id="name"
+                type="text"
+                placeholder={t('form.namePlaceholder')}
+                className="input input-bordered w-full"
+              />
+            </div>
+            <div className="form-control">
+              <label className="label" htmlFor="email">
+                <span className="label-text">{t('form.email')}</span>
+              </label>
+              <input
+                id="email"
+                type="email"
+                placeholder={t('form.emailPlaceholder')}
+                className="input input-bordered w-full"
+              />
+            </div>
+            <div className="form-control">
+              <label className="label" htmlFor="category">
+                <span className="label-text">{t('form.category')}</span>
+              </label>
+              <select id="category" className="select select-bordered w-full">
+                <option>{t('categories.featureIdeas')}</option>
+                <option>{t('categories.reportBug')}</option>
+                <option>{t('categories.troubles')}</option>
+                <option>{t('categories.delivery')}</option>
+                <option>{t('categories.credits')}</option>
+                <option>{t('categories.general')}</option>
+              </select>
+            </div>
+            <div className="form-control">
+              <label className="label" htmlFor="message">
+                <span className="label-text">{t('form.message')}</span>
+              </label>
+              <textarea
+                id="message"
+                className="textarea textarea-bordered h-32"
+              ></textarea>
+            </div>
+            <button type="submit" className="btn btn-primary">
+              {t('form.submit')}
+            </button>
+          </form>
+        </section>
+
+        <section>
+          <h2 className="text-3xl font-bold mb-4">{t('join.title')}</h2>
+          <p className="mb-4">{t('join.intro')}</p>
+          <ul className="list-disc list-inside space-y-2 mb-4">
+            <li>{t('join.printing')}</li>
+            <li>{t('join.country')}</li>
+            <li>{t('join.developers')}</li>
+          </ul>
+          <p>{t('join.call')}</p>
+        </section>
+
+        <section>
+          <h2 className="text-2xl font-semibold mb-2">{t('bonus.title')}</h2>
+          <p className="mb-2">{t('bonus.content')}</p>
+          <p className="mb-4 text-sm">{t('bonus.disclaimer')}</p>
+          <p className="font-semibold">{t('bonus.closing')}</p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/messages/en-US/publicPages.json
+++ b/src/messages/en-US/publicPages.json
@@ -247,4 +247,42 @@
       "createdBy": "Created by"
     }
   }
+  ,"ContactUsPage": {
+    "title": "Contact Mythoria",
+    "intro": "Greetings, fellow adventurer! Whether you're from the Shire, Hogwarts, or a galaxy far, far away, we're here to assist you in your journey through the wonderful world of Mythoria. Your feedback is as precious as the One Ring (but easier to handle, we promise!).",
+    "scrollTitle": "Send Us Your Owl (or just fill the form)",
+    "scrollIntro": "Choose the scroll that best suits your quest:",
+    "categories": {
+      "featureIdeas": "Feature Ideas (Inspire us like Tolkien)",
+      "reportBug": "Report a Bug (Even Sherlock Holmes needed clues!)",
+      "troubles": "Story Generation Troubles (When the magic spells go awry)",
+      "delivery": "Printed Book Delivery (Our owls might need directions)",
+      "credits": "Credits & Payments (The goblins at Gringotts are strict!)",
+      "general": "General Enchantment (Support)"
+    },
+    "form": {
+      "title": "The Magic Form",
+      "name": "Your Name:",
+      "namePlaceholder": "Wizarding Alias",
+      "email": "Your Email:",
+      "emailPlaceholder": "So our carrier pigeons can find you",
+      "category": "Select Your Quest:",
+      "message": "Your Magical Message:",
+      "submit": "Cast Spell"
+    },
+    "join": {
+      "title": "Join the Fellowship",
+      "intro": "Mythoria is on an epic quest to conquer new realms and we are looking for brave souls to join our fellowship!",
+      "printing": "Printing & Logistics Partners: Are you ready to journey across Middle-earth or Westeros to deliver stories that matter? Join us in spreading the magic of personalized storytelling.",
+      "country": "Country Managers & Local Wizards: Help Mythoria take over the world (peacefully, we assure you). Bring the joy of storytelling to your kingdom and beyond!",
+      "developers": "Developers Who Vibe Code & Speak AI: Do you speak fluent binary and chat effortlessly with AI? We need skilled developers who vibe with innovative technology and artificial intelligence to enhance the Mythoria experience.",
+      "call": "Interested in becoming a Mythorian? Send us your details using the enchanted form above, and let us know your area of interest."
+    },
+    "bonus": {
+      "title": "Bonus Credits Alert!",
+      "content": "Have a sharp eye for bugs or an imaginative mind bursting with ideas? Earn extra magical credits for every valid bug reported or inspired feature suggested.",
+      "disclaimer": "(*) Final decision rests with our delightful Oompa Loompas. They're charmingly unpredictable, but they love rewarding creativity!",
+      "closing": "Let's create magic together!"
+    }
+  }
 }

--- a/src/messages/pt-PT/publicPages.json
+++ b/src/messages/pt-PT/publicPages.json
@@ -248,4 +248,42 @@
       "createdBy": "Criado por"
     }
   }
+  ,"ContactUsPage": {
+    "title": "Contacte a Mythoria",
+    "intro": "Saudações, aventureiro! Seja da Terra Média, de Hogwarts ou de uma galáxia muito distante, estamos aqui para ajudar na sua jornada pelo maravilhoso mundo da Mythoria. O seu feedback é precioso como o Anel, mas bem mais fácil de carregar!",
+    "scrollTitle": "Envie-nos a sua Coruja (ou preencha o formulário)",
+    "scrollIntro": "Escolha o pergaminho que melhor se adapta à sua missão:",
+    "categories": {
+      "featureIdeas": "Ideias de Funcionalidades (Inspire-nos como Tolkien)",
+      "reportBug": "Reportar um Erro (Até Sherlock Holmes precisava de pistas!)",
+      "troubles": "Problemas na Geração de Histórias (Quando os feitiços falham)",
+      "delivery": "Entrega de Livro Impresso (As nossas corujas podem precisar de direções)",
+      "credits": "Créditos & Pagamentos (Os duendes de Gringotes são exigentes!)",
+      "general": "Encantamento Geral (Suporte)"
+    },
+    "form": {
+      "title": "O Formulário Mágico",
+      "name": "O Seu Nome:",
+      "namePlaceholder": "Ou Alcunha de Feiticeiro",
+      "email": "O Seu Email:",
+      "emailPlaceholder": "Para as nossas pombas mensageiras",
+      "category": "Selecione a Sua Missão:",
+      "message": "A Sua Mensagem Mágica:",
+      "submit": "Lançar Feitiço"
+    },
+    "join": {
+      "title": "Junte-se à Irmandade",
+      "intro": "A Mythoria está numa missão épica para conquistar novos reinos e procura bravos aventureiros para se juntarem à nossa irmandade!",
+      "printing": "Parceiros de Impressão & Logística: preparados para atravessar a Terra Média ou Westeros para entregar histórias inesquecíveis? Juntem-se a nós e espalhem a magia da narração personalizada.",
+      "country": "Gestores de País & Feiticeiros Locais: ajudem a Mythoria a conquistar o mundo (pacificamente, prometemos). Levem a alegria da narração ao vosso reino e além!",
+      "developers": "Programadores que Vibrem Código & Falem IA: dominam a linguagem binária e conversam facilmente com IA? Precisamos de programadores que vibrem com tecnologia inovadora e inteligência artificial para aprimorar a experiência Mythoria.",
+      "call": "Interessado em tornar-se Mythoriano? Envie-nos os seus dados através do formulário encantado acima e indique a sua área de interesse."
+    },
+    "bonus": {
+      "title": "Alerta de Créditos Bónus!",
+      "content": "Olhos de águia para bugs ou uma mente imaginativa cheia de ideias? Ganhe créditos mágicos extra por cada bug válido ou funcionalidade inspirada que sugerir.",
+      "disclaimer": "(*) A decisão final cabe aos nossos adoráveis Oompa Loompas. São imprevisíveis, mas adoram recompensar a criatividade!",
+      "closing": "Vamos criar magia juntos!"
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- implement new public ContactUs page with basic form
- provide translations for ContactUs in English and Portuguese

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68559ff5dc588328b74a5623b044355f