### PR TITLE
feat(i18n): localize PublicStoryRating

### DIFF
--- a/src/components/PublicStoryRating.tsx
+++ b/src/components/PublicStoryRating.tsx
@@ -175,7 +175,10 @@ export default function PublicStoryRating({ storyId, onRatingSubmitted }: Public
           onMouseEnter={() => setHoveredRating(star)}
           onMouseLeave={() => setHoveredRating(0)}
           disabled={isSubmitting}
-          title={`Rate ${star} star${star !== 1 ? 's' : ''}`}
+          title={t('starTooltip', {
+            count: star,
+            plural: star !== 1 ? 's' : '',
+          })}
         >
           <FiStar 
             className={
@@ -209,7 +212,7 @@ export default function PublicStoryRating({ storyId, onRatingSubmitted }: Public
       <div className="card-body">
         <div className="text-center">
           <h3 className="card-title justify-center mb-4">
-            {t('title') || 'Rate this Story'}
+            {t('title')}
           </h3>
 
           {/* Unified Star Rating Display */}
@@ -226,20 +229,29 @@ export default function PublicStoryRating({ storyId, onRatingSubmitted }: Public
                   {ratingData.averageRating.toFixed(1)}/5
                 </p>
                 <p className="text-sm text-base-content/70">
-                  Based on {ratingData.totalRatings} rating{ratingData.totalRatings !== 1 ? 's' : ''}
+                  {t('basedOnRatings', {
+                    count: ratingData.totalRatings,
+                    plural: ratingData.totalRatings !== 1 ? 's' : '',
+                  })}
                 </p>
                 {hoveredRating > 0 && (
                   <p className="text-sm text-info mt-2">
-                    Click to rate {hoveredRating} star{hoveredRating !== 1 ? 's' : ''}
+                    {t('clickToRate', {
+                      count: hoveredRating,
+                      plural: hoveredRating !== 1 ? 's' : '',
+                    })}
                   </p>
                 )}
               </div>
             ) : (
               <div className="text-center">
-                <p className="text-base-content/70 mb-2">No ratings yet</p>
+                <p className="text-base-content/70 mb-2">{t('noRatingsYet')}</p>
                 {hoveredRating > 0 && (
                   <p className="text-sm text-info">
-                    Click to rate {hoveredRating} star{hoveredRating !== 1 ? 's' : ''}
+                    {t('clickToRate', {
+                      count: hoveredRating,
+                      plural: hoveredRating !== 1 ? 's' : '',
+                    })}
                   </p>
                 )}
               </div>
@@ -250,7 +262,7 @@ export default function PublicStoryRating({ storyId, onRatingSubmitted }: Public
           {ratingData?.userRating && !submitted && (
             <div className="mb-4 p-3 bg-info/10 rounded-lg border border-info/20">
               <p className="text-sm text-info">
-                Your current rating: {ratingData.userRating.rating} ⭐ 
+                {t('yourCurrentRating')}: {ratingData.userRating.rating} ⭐
                 {ratingData.userRating.createdAt && (
                   <span className="ml-2 text-xs">
                     ({new Date(ratingData.userRating.createdAt).toLocaleDateString()})
@@ -268,7 +280,7 @@ export default function PublicStoryRating({ storyId, onRatingSubmitted }: Public
             <form onSubmit={handleFeedbackSubmit} className="mt-6 space-y-4 border-t pt-4">
               <div className="text-center mb-4">
                 <p className="text-sm text-base-content/70">
-                  You selected: <span className="font-semibold">{userRating} star{userRating !== 1 ? 's' : ''}</span>
+                  {t('youSelected')} <span className="font-semibold">{userRating} star{userRating !== 1 ? 's' : ''}</span>
                 </p>
               </div>
               
@@ -323,7 +335,7 @@ export default function PublicStoryRating({ storyId, onRatingSubmitted }: Public
                       {t('buttons.submitting')}
                     </>
                   ) : (
-                    ratingData?.userRating ? (t('buttons.updateRating') || 'Update Rating') : t('buttons.submitRating')
+                    ratingData?.userRating ? t('buttons.updateRating') : t('buttons.submitRating')
                   )}
                 </button>
               </div>

--- a/src/messages/en-US/common.json
+++ b/src/messages/en-US/common.json
@@ -304,16 +304,22 @@
 				"audioPlaybackError": "An error occurred during audio playback. Please refresh the page and try again."
 			}
 		},
-		"storyRating": {
-			"title": "Rate this story",
-			"titleUpdate": "Update Your Rating",
-			"currentRating": "Current Rating",
-			"averageRating": "Average Rating",
-			"totalRatings": "Total Ratings",
-			"feedback": {
-				"title": "What could we improve? (Optional)",
-				"placeholder": "Your feedback helps us create better stories...",
-				"includeNameLabel": "Allow the author to see my name with this feedback"
+                "storyRating": {
+                        "title": "Rate this story",
+                        "titleUpdate": "Update Your Rating",
+                        "currentRating": "Current Rating",
+                        "averageRating": "Average Rating",
+                        "totalRatings": "Total Ratings",
+                        "basedOnRatings": "Based on {count} rating{plural}",
+                        "clickToRate": "Click to rate {count} star{plural}",
+                        "noRatingsYet": "No ratings yet",
+                        "yourCurrentRating": "Your current rating",
+                        "youSelected": "You selected:",
+                        "starTooltip": "Rate {count} star{plural}",
+                        "feedback": {
+                                "title": "What could we improve? (Optional)",
+                                "placeholder": "Your feedback helps us create better stories...",
+                                "includeNameLabel": "Allow the author to see my name with this feedback"
 			},
 			"buttons": {
 				"cancel": "Cancel",

--- a/src/messages/pt-PT/common.json
+++ b/src/messages/pt-PT/common.json
@@ -317,6 +317,12 @@
       "currentRating": "Avaliação Atual",
       "averageRating": "Avaliação Média",
       "totalRatings": "Total de Avaliações",
+      "basedOnRatings": "Com base em {count} avaliação{plural}",
+      "clickToRate": "Clique para avaliar {count} estrela{plural}",
+      "noRatingsYet": "Sem avaliações ainda",
+      "yourCurrentRating": "A sua avaliação",
+      "youSelected": "Selecionou:",
+      "starTooltip": "Avaliar {count} estrela{plural}",
       "feedback": {
         "title": "O que podemos melhorar? (Opcional)",
         "placeholder": "O seu feedback ajuda-nos a criar melhores histórias...",


### PR DESCRIPTION
## Summary
- add translations for PublicStoryRating strings
- use translations in `PublicStoryRating` component

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_687bd2296c04832886b60c0af950c31b