### PR TITLE
Update pricing modal translation

### DIFF
--- a/src/app/[locale]/pricing/page.tsx
+++ b/src/app/[locale]/pricing/page.tsx
@@ -335,10 +335,10 @@ export default function PricingPage() {
 			{selectedInfo && (
 				<div className="modal modal-open">
 					<div className="modal-box w-10/12 max-w-xs sm:max-w-sm md:max-w-md lg:max-w-lg mx-4">
-						<h3 className="font-bold text-lg mb-4">Information</h3>
+                                                <h3 className="font-bold text-lg mb-4">{t('infoModal.title')}</h3>
 						<p className="py-2">{infoTexts[selectedInfo as keyof typeof infoTexts]}</p>
 						<div className="modal-action">
-							<button className="btn" onClick={closeModal}>Close</button>
+                                                        <button className="btn" onClick={closeModal}>{t('infoModal.close')}</button>
 						</div>
 					</div>
 					<div className="modal-backdrop" onClick={closeModal}></div>

--- a/src/messages/en-US/pricing.json
+++ b/src/messages/en-US/pricing.json
@@ -54,6 +54,7 @@
       "creditsUnit": "Credits"
     },
     "infoModal": {
+      "title": "Service Information",
       "header": "Service Information",
       "button": "More Info",
       "services": {

--- a/src/messages/pt-PT/pricing.json
+++ b/src/messages/pt-PT/pricing.json
@@ -54,6 +54,7 @@
       "creditsUnit": "Créditos"
     },
     "infoModal": {
+      "title": "Informações do Serviço",
       "header": "Informações do Serviço",
       "button": "Mais Informações",
       "services": {


### PR DESCRIPTION
## Summary
- add infoModal.title to pricing messages
- translate pricing info modal labels

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_687bdef0efb88328bbe10381acc62e58