### PR TITLE
Fix localization for order error

### DIFF
--- a/src/app/[locale]/buy-credits/page.tsx
+++ b/src/app/[locale]/buy-credits/page.tsx
@@ -333,7 +333,7 @@ function BuyCreditsContent() {
 			const data = await response.json();
 
 			if (!response.ok) {
-				throw new Error(data.error || 'Failed to create order');
+                                throw new Error(data.error || t('errors.orderCreationFailed'));
 			}
 
 			console.log('Order created successfully:', data);
@@ -653,9 +653,9 @@ function BuyCreditsContent() {
 								className="radio radio-primary"
 							/>
 							<div className="flex items-center space-x-2">
-								<Image 
-									src="/images/mbway.png" 
-									alt="MB Way" 
+                                                                <Image
+                                                                        src="/images/mbway.png"
+                                                                        alt={t('payment.mbway')}
 									width={24}
 									height={24}
 									className="object-contain" 


### PR DESCRIPTION
## Summary
- reference translations for order creation failure messages
- localize MB Way alt text

## Testing
- `npm run lint`
- `npm run build` *(fails: <Html> import outside _document)*

------
https://chatgpt.com/codex/tasks/task_e_687bdeedb4c08328bbec27c876e5035d