### PR TITLE
Add translated labels for step 3 page

### DIFF
--- a/src/app/[locale]/tell-your-story/step-3/page.tsx
+++ b/src/app/[locale]/tell-your-story/step-3/page.tsx
@@ -258,7 +258,7 @@ function Step3Page() {
 
     } catch (error) {
       console.error('Error adding existing character:', error);
-      alert('Failed to add character to story. Please try again.');
+      alert(t('alerts.failedToAddCharacter'));
     }
   };
 
@@ -344,7 +344,7 @@ function Step3Page() {
 
     } catch (error) {
       console.error('Error navigating to next step:', error);
-      alert('Failed to continue. Please try again.');
+      alert(t('alerts.failedToContinue'));
     } finally {
       setIsNavigating(false);
     }
@@ -368,8 +368,8 @@ function Step3Page() {
               <>
                 {/* Mobile Progress Indicator */}
                 <div className="block md:hidden mb-8">
-                  <div className="text-center text-sm text-gray-600 mb-2">
-                    Step {currentStep} of {totalSteps}
+                <div className="text-center text-sm text-gray-600 mb-2">
+                    {t('progress.stepLabel', { currentStep, totalSteps })}
                   </div>
                   <progress
                     className="progress progress-primary w-full"
@@ -399,7 +399,7 @@ function Step3Page() {
                 <h1 className="card-title text-3xl">{t('heading')}</h1>
                 {isInEditMode && (
                   <div className="badge badge-info">
-                    Editing Draft Story
+                    {t('badges.editingDraft')}
                   </div>
                 )}
               </div>

--- a/src/messages/en-US/storySteps.json
+++ b/src/messages/en-US/storySteps.json
@@ -134,6 +134,9 @@
       "greatWork": "Great work! You've created {count, plural, =1 {# character} other {# characters}}.",
       "youCanAlways": "You can always add more characters later or continue to the next chapter to develop your story further.",
       "continuing": "Continuing...",
+      "progress": {
+        "stepLabel": "Step {currentStep} of {totalSteps}"
+      },
       "badges": {
         "editingDraft": "Editing Draft Story"
       },
@@ -144,7 +147,9 @@
         "failedToLoadStoryCharacters": "Failed to load story characters. Please try again.",
         "characterLoadError": "Error loading characters. Please refresh the page.",
         "failedToLoadStoryData": "Failed to load story data. Please try again.",
-        "failedToLoadStoryForEditing": "Failed to load story for editing. Please try again."
+        "failedToLoadStoryForEditing": "Failed to load story for editing. Please try again.",
+        "failedToAddCharacter": "Failed to add character to story. Please try again.",
+        "failedToContinue": "Failed to continue. Please try again."
       },
       "next": "Next"
     },

--- a/src/messages/pt-PT/storySteps.json
+++ b/src/messages/pt-PT/storySteps.json
@@ -134,6 +134,9 @@
       "greatWork": "Bom trabalho! Criaste {count, plural, =1 {# personagem} other {# personagens}}.",
       "youCanAlways": "Podes sempre adicionar mais personagens mais tarde ou avançar para o próximo capítulo para desenvolver ainda mais a tua história.",
       "continuing": "A continuar...",
+      "progress": {
+        "stepLabel": "Passo {currentStep} de {totalSteps}"
+      },
       "badges": {
         "editingDraft": "A Editar Rascunho da História"
       },
@@ -144,7 +147,9 @@
         "failedToLoadStoryCharacters": "Falha ao carregar personagens da história. Por favor tente novamente.",
         "characterLoadError": "Erro ao carregar personagens. Por favor atualize a página.",
         "failedToLoadStoryData": "Falha ao carregar dados da história. Por favor tente novamente.",
-        "failedToLoadStoryForEditing": "Falha ao carregar história para edição. Por favor tente novamente."
+        "failedToLoadStoryForEditing": "Falha ao carregar história para edição. Por favor tente novamente.",
+        "failedToAddCharacter": "Falha ao adicionar personagem à história. Por favor tente novamente.",
+        "failedToContinue": "Falha ao continuar. Por favor tente novamente."
       },
       "next": "Seguinte"
     },


### PR DESCRIPTION
## Summary
- use translation keys for progress label and edit badge
- translate alerts for adding characters and continuing
- add missing message keys to translations

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68827c00b3ac8328b50f0e008a753de0