### PR TITLE
Add translations for image instructions

### DIFF
--- a/src/app/[locale]/tell-your-story/step-4/page.tsx
+++ b/src/app/[locale]/tell-your-story/step-4/page.tsx
@@ -87,7 +87,7 @@ function Step4Page() {
     if (novelStyle) parts.push(NovelStyleLabels[novelStyle]);
     if (graphicalStyle) parts.push(GraphicalStyleLabels[graphicalStyle]);
     if (place.trim()) parts.push(place.trim());
-    if (imageGenerationInstructions.trim()) parts.push('Custom image instructions');
+    if (imageGenerationInstructions.trim()) parts.push(t('previews.customImageInstructions'));
     return parts.join(', ');
   };
 
@@ -187,7 +187,7 @@ function Step4Page() {
       }
     } catch (error) {
       console.error('Error fetching story data:', error);
-      setError('Failed to load story information. Please try again.');
+      setError(t('errors.loadFailed'));
     } finally {
       setLoading(false);
     }
@@ -554,19 +554,19 @@ function Step4Page() {
                           {/* Custom Image Instructions Field */}
                           <div className="form-control md:col-span-2">
                             <label className="label">
-                              <span className="label-text font-semibold">Custom Image Instructions</span>
+                              <span className="label-text font-semibold">{t('fields.imageInstructions')}</span>
                             </label>
                             <textarea
                               value={imageGenerationInstructions}
                               onChange={(e) => setImageGenerationInstructions(e.target.value)}
-                              placeholder="Describe how you&apos;d like the characters to look, specific visual elements, colors, or artistic details for your story images..."
+                              placeholder={t('placeholders.imageInstructions')}
                               className="textarea textarea-bordered h-24 w-full"
                               rows={4}
                               maxLength={1000}
                             />
                             <label className="label">
                               <span className="label-text-alt break-words max-w-full whitespace-normal">
-                                Provide specific instructions to customize the AI-generated images. Describe character appearances, visual style preferences, or any special elements you&apos;d like included.
+                                {t('fields.imageInstructionsHelp')}
                                 {imageGenerationInstructions.length > 0 && (
                                   <span className="ml-2 text-sm">({imageGenerationInstructions.length}/1000)</span>
                                 )}

--- a/src/messages/en-US/storySteps.json
+++ b/src/messages/en-US/storySteps.json
@@ -162,6 +162,8 @@
         "novelStyleHelp": "What genre/style should your story be?",
         "graphicStyle": "Graphic Style",
         "graphicStyleHelp": "Choose the artistic style for your story's illustrations",
+        "imageInstructions": "Custom Image Instructions",
+        "imageInstructionsHelp": "Provide specific instructions to customize the AI-generated images. Describe character appearances, visual style preferences, or any special elements you'd like included.",
         "bookSize": "Book Size",
         "bookSizeHelp": "Number of chapters/paragraphs in your story",
         "storyLanguage": "Story Language",
@@ -175,6 +177,7 @@
         "selectAudience": "Select target audience...",
         "selectNovelStyle": "Select novel style...",
         "selectGraphicStyle": "Select graphic style...",
+        "imageInstructions": "Describe how you'd like the characters to look, specific visual elements, colors, or artistic details for your story images...",
         "outlinePlaceholder": "Describe all the details you'd like in the story...",
         "storyLanguageHelp": "Your story will be written and generated in the selected language."
       },
@@ -206,7 +209,8 @@
       },
       "previews": {
         "storyOutlineProvided": "Story outline provided",
-        "additionalRequestsProvided": "Additional requests provided"
+        "additionalRequestsProvided": "Additional requests provided",
+        "customImageInstructions": "Custom image instructions"
       },
       "modal": {
         "title": "Graphical Style Samples",
@@ -225,7 +229,8 @@
         "graphicStyleRequired": "Graphic style is required before proceeding to the next step. Please open the \"Style & Setting\" section.",
         "noStoryFound": "No story found. Please start from step 1.",
         "saveFailed": "Failed to save story details",
-        "saveFailedTryAgain": "Failed to save story details. Please try again."
+        "saveFailedTryAgain": "Failed to save story details. Please try again.",
+        "loadFailed": "Failed to load story information. Please try again."
       },
       "saving": "Saving...",
       "next": "Next"

--- a/src/messages/pt-PT/storySteps.json
+++ b/src/messages/pt-PT/storySteps.json
@@ -162,6 +162,8 @@
         "novelStyleHelp": "Que género/estilo deve ter a tua história?",
         "graphicStyle": "Estilo Gráfico",
         "graphicStyleHelp": "Escolhe o estilo artístico das ilustrações da tua história",
+        "imageInstructions": "Instruções de Imagem Personalizadas",
+        "imageInstructionsHelp": "Fornece instruções específicas para personalizar as imagens geradas por IA. Descreve a aparência das personagens, preferências de estilo visual ou quaisquer elementos especiais que queiras incluir.",
         "bookSize": "Tamanho do Livro",
         "bookSizeHelp": "Número de capítulos/parágrafos na tua história",
         "storyLanguage": "Idioma da História",
@@ -175,6 +177,7 @@
         "selectAudience": "Selecionar público-alvo...",
         "selectNovelStyle": "Selecionar estilo de romance...",
         "selectGraphicStyle": "Selecionar estilo gráfico...",
+        "imageInstructions": "Descreve como gostarias que as personagens aparentassem, elementos visuais específicos, cores ou detalhes artísticos para as imagens da tua história...",
         "outlinePlaceholder": "Descreva todos os detalhes que gostaria na história...",
         "storyLanguageHelp": "A tua história será escrita e gerada no idioma selecionado."
       },
@@ -206,7 +209,8 @@
       },
       "previews": {
         "storyOutlineProvided": "Esboço da história fornecido",
-        "additionalRequestsProvided": "Pedidos adicionais fornecidos"
+        "additionalRequestsProvided": "Pedidos adicionais fornecidos",
+        "customImageInstructions": "Instruções de imagem personalizadas"
       },
       "modal": {
         "title": "Amostras de Estilos Gráficos",
@@ -225,7 +229,8 @@
         "graphicStyleRequired": "O estilo gráfico é obrigatório antes de prosseguir para o próximo passo. Por favor, abra a secção \"Estilo e Cenário\".",
         "noStoryFound": "Nenhuma história encontrada. Por favor, comece pelo passo 1.",
         "saveFailed": "Falha ao guardar detalhes da história",
-        "saveFailedTryAgain": "Falha ao guardar detalhes da história. Por favor, tente novamente."
+        "saveFailedTryAgain": "Falha ao guardar detalhes da história. Por favor, tente novamente.",
+        "loadFailed": "Falha ao carregar informações da história. Por favor, tenta novamente."
       },
       "saving": "A guardar...",
       "next": "Próximo"


### PR DESCRIPTION
## Summary
- support custom image instructions in step 4 form
- include new translation keys for English and Portuguese
- use translated strings in step 4

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68827c0291f4832897619c5a31231322