### PR TITLE
Fix step 5 error translations

### DIFF
--- a/src/app/[locale]/tell-your-story/step-5/page.tsx
+++ b/src/app/[locale]/tell-your-story/step-5/page.tsx
@@ -122,12 +122,12 @@ function Step5Page() {
 
   const handleCompleteStory = async () => {
     if (!currentStoryId || !storyData || !ebookPricing) {
-      setError('Story data not available');
+      setError(t('storyDataNotAvailable'));
       return;
     }
 
     if (hasInsufficientCredits()) {
-      setError('You have insufficient credits. Please purchase more credits to continue.');
+      setError(t('alerts.insufficientCreditsError'));
       return;
     }
 
@@ -200,7 +200,7 @@ function Step5Page() {
       setStoryGenerationStarted(true);
     } catch (error) {
       console.error('Error completing story:', error);
-      setError(error instanceof Error ? error.message : 'Failed to complete story');
+      setError(error instanceof Error ? error.message : t('alerts.failedToCompleteStory'));
     } finally {
       setSubmitting(false);
     }

--- a/src/messages/en-US/storySteps.json
+++ b/src/messages/en-US/storySteps.json
@@ -259,7 +259,9 @@
         "failedToDeductCredits": "Failed to deduct credits. Please try again.",
         "dataFetchError": "Error fetching data. Please check your connection and try again.",
         "failedToLoadCreditInformation": "Failed to load credit information. Please try again.",
-        "failedToLoadPricingInformation": "Failed to load pricing information. Please try again."
+        "failedToLoadPricingInformation": "Failed to load pricing information. Please try again.",
+        "insufficientCreditsError": "You have insufficient credits. Please purchase more credits to continue.",
+        "failedToCompleteStory": "Failed to complete story. Please try again."
       }
     }
   }

--- a/src/messages/pt-PT/storySteps.json
+++ b/src/messages/pt-PT/storySteps.json
@@ -259,7 +259,9 @@
         "failedToDeductCredits": "Falha ao deduzir créditos. Por favor tente novamente.",
         "dataFetchError": "Erro ao obter dados. Por favor verifique a sua ligação e tente novamente.",
         "failedToLoadCreditInformation": "Falha ao carregar informação de créditos. Por favor tente novamente.",
-        "failedToLoadPricingInformation": "Falha ao carregar informação de preços. Por favor tente novamente."
+        "failedToLoadPricingInformation": "Falha ao carregar informação de preços. Por favor tente novamente.",
+        "insufficientCreditsError": "Tens créditos insuficientes. Compra mais créditos para continuares.",
+        "failedToCompleteStory": "Falha ao completar a história. Por favor tenta novamente."
       }
     }
   }


### PR DESCRIPTION
## Summary
- localize error messages in step 5 page
- add messages for insufficient credits and completion failure in translation files

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68827c0411f08328be42e37aad700e16