### PR TITLE
Localize public page load errors

### DIFF
--- a/src/app/[locale]/p/[slug]/chapter/[chapterNumber]/page.tsx
+++ b/src/app/[locale]/p/[slug]/chapter/[chapterNumber]/page.tsx
@@ -63,11 +63,11 @@ export default function PublicChapterPage() {
         if (result.success) {
           setData(result);
         } else {
-          setError(result.error || 'Failed to load chapter');
+          setError(result.error || tPublicStoryPage('errors.failedToLoadChapter'));
         }
       } catch (err) {
         console.error('Error fetching public chapter:', err);
-        setError('Failed to load chapter');
+        setError(tPublicStoryPage('errors.failedToLoadChapter'));
       } finally {
         setLoading(false);
       }

--- a/src/app/[locale]/p/[slug]/listen/page.tsx
+++ b/src/app/[locale]/p/[slug]/listen/page.tsx
@@ -90,12 +90,12 @@ export default function PublicListenPage() {
           console.log('[Public Listen Page] Story loaded successfully');
         } else {
           console.error('[Public Listen Page] API returned error:', result.error);
-          setError(result.error || 'Story not found');
+          setError(result.error || t('errors.notFound'));
         }
       } catch (err) {
         console.error('[Public Listen Page] Error fetching public story:', err);
         const errorMessage = err instanceof Error ? err.message : 'Unknown error';
-        setError(`Failed to load story: ${errorMessage}`);
+        setError(`${t('errors.failedToLoadStory')}: ${errorMessage}`);
       } finally {
         setLoading(false);
       }

--- a/src/app/[locale]/p/[slug]/page.tsx
+++ b/src/app/[locale]/p/[slug]/page.tsx
@@ -82,12 +82,12 @@ export default function PublicStoryPage() {
           
         } else {
           console.error('[Public Page] API returned error:', result.error);
-          setError(result.error || 'Story not found');
+          setError(result.error || t('errors.notFound'));
         }
       } catch (err) {
         console.error('[Public Page] Error fetching public story:', err);
         const errorMessage = err instanceof Error ? err.message : 'Unknown error';
-        setError(`Failed to load story: ${errorMessage}`);
+        setError(`${t('errors.failedToLoadStory')}: ${errorMessage}`);
       } finally {
         setLoading(false);
       }

--- a/src/messages/en-US/PublicStoryPage.json
+++ b/src/messages/en-US/PublicStoryPage.json
@@ -20,7 +20,9 @@
       "notFound": "Story Not Found",
       "notFoundDesc": "The story you're looking for doesn't exist or is no longer public.",
       "contentNotAvailable": "Content Not Available",
-      "contentNotAvailableDesc": "The story content is not currently available for reading."
+      "contentNotAvailableDesc": "The story content is not currently available for reading.",
+      "failedToLoadStory": "Failed to load story",
+      "failedToLoadChapter": "Failed to load chapter"
     },
     "actions": {
       "orderPrint": "Order Print",

--- a/src/messages/pt-PT/PublicStoryPage.json
+++ b/src/messages/pt-PT/PublicStoryPage.json
@@ -20,7 +20,9 @@
       "notFound": "História Não Encontrada",
       "notFoundDesc": "A história que procura não existe ou já não é pública.",
       "contentNotAvailable": "Conteúdo Não Disponível",
-      "contentNotAvailableDesc": "O conteúdo da história não está atualmente disponível para leitura."
+      "contentNotAvailableDesc": "O conteúdo da história não está atualmente disponível para leitura.",
+      "failedToLoadStory": "Falha ao carregar história",
+      "failedToLoadChapter": "Falha ao carregar capítulo"
     },
     "actions": {
       "orderPrint": "Encomendar Impressão",


### PR DESCRIPTION
## Summary
- add `failedToLoadStory` and `failedToLoadChapter` messages to locales
- use translations when displaying public page errors

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68827c0807f48328a94efcb5e0a49da4