### PR TITLE
Add error translation for chapter editor

### DIFF
--- a/src/app/[locale]/stories/edit/[storyId]/chapter/[chapterNumber]/page.tsx
+++ b/src/app/[locale]/stories/edit/[storyId]/chapter/[chapterNumber]/page.tsx
@@ -116,7 +116,7 @@ export default function EditChapterPage() {
       }
     } catch (error) {
       console.error('Error loading story:', error);
-      addToast('Failed to load story data', 'error');
+      addToast(tComponents('chapterEditor.errors.failedToLoadStoryData'), 'error');
     } finally {
       setLoading(false);
     }

--- a/src/messages/en-US/components.json
+++ b/src/messages/en-US/components.json
@@ -78,6 +78,9 @@
         "medium": "M",
         "large": "L",
         "xlarge": "XL"
+      },
+      "errors": {
+        "failedToLoadStoryData": "Failed to load story data"
       }
     },
     "chapterNavigation": {

--- a/src/messages/pt-PT/components.json
+++ b/src/messages/pt-PT/components.json
@@ -78,6 +78,9 @@
         "medium": "M",
         "large": "G",
         "xlarge": "XG"
+      },
+      "errors": {
+        "failedToLoadStoryData": "Falha ao carregar dados da história"
       }
     },
     "chapterNavigation": {


### PR DESCRIPTION
## Summary
- add missing `failedToLoadStoryData` key under `chapterEditor.errors`
- use the new translation in the chapter editor toast

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68827c0b08408328a2c425dac7b5f167