### PR TITLE
Localize AIEditModal strings

### DIFF
--- a/src/components/AIEditModal.tsx
+++ b/src/components/AIEditModal.tsx
@@ -207,12 +207,12 @@ export default function AIEditModal({
       const creditData = await creditCheckResponse.json();
 
       if (!creditCheckResponse.ok) {
-        setError(creditData.error || 'Failed to check credit requirements');
+        setError(creditData.error || t('errors.checkCreditsFailed'));
         return;
       }
 
       if (!creditData.canEdit) {
-        setError(creditData.message || 'Insufficient credits for this edit');
+        setError(creditData.message || t('errors.insufficientCredits'));
         return;
       }
 
@@ -236,7 +236,7 @@ export default function AIEditModal({
 
     } catch (error) {
       console.error('Error checking credits:', error);
-      setError('Failed to check credit requirements. Please try again.');
+      setError(t('errors.checkCreditsFailedRetry'));
     }
   };
 
@@ -323,7 +323,7 @@ export default function AIEditModal({
     } catch (error) {
       console.error('Error updating image:', error);
       setIsSavingImage(false);
-      setError('Failed to update image. Please try again.');
+      setError(t('errors.updateImageFailed'));
     }
   };
 
@@ -557,9 +557,9 @@ export default function AIEditModal({
             <div className="flex flex-col items-center gap-4">
               <span className="loading loading-spinner loading-lg text-primary"></span>
               <div>
-                <h3 className="text-lg font-semibold">Saving Image Changes</h3>
+                <h3 className="text-lg font-semibold">{t('imageSave.title')}</h3>
                 <p className="text-sm text-base-content/70 mt-2">
-                  Please wait while we save your image changes to the story...
+                  {t('imageSave.description')}
                 </p>
               </div>
             </div>

--- a/src/messages/en-US/common.json
+++ b/src/messages/en-US/common.json
@@ -360,9 +360,17 @@
 				"requestTooLong": "Request must be 2000 characters or less",
 				"editFailed": "Failed to edit story. Please try again.",
 				"describeChanges": "Please describe the changes you want to make to the image",
-				"unableToCheckCredits": "Unable to check credits. Please try again."
-			}
-		},
+                                "unableToCheckCredits": "Unable to check credits. Please try again.",
+                                "checkCreditsFailed": "Failed to check credit requirements",
+                                "checkCreditsFailedRetry": "Failed to check credit requirements. Please try again.",
+                                "insufficientCredits": "Insufficient credits for this edit",
+                                "updateImageFailed": "Failed to update image. Please try again."
+                        },
+                        "imageSave": {
+                                "title": "Saving Image Changes",
+                                "description": "Please wait while we save your image changes to the story..."
+                        }
+                },
 		"aiImageEditor": {
 			"errors": {
 				"describeChanges": "Please describe the changes you want to make to the image",

--- a/src/messages/pt-PT/common.json
+++ b/src/messages/pt-PT/common.json
@@ -365,7 +365,15 @@
       "errors": {
         "enterRequest": "Por favor, insira o seu pedido de edição",
         "requestTooLong": "O pedido deve ter 2000 caracteres ou menos",
-        "editFailed": "Falha ao editar a história. Tente novamente."
+        "editFailed": "Falha ao editar a história. Tente novamente.",
+        "checkCreditsFailed": "Falha ao verificar os requisitos de crédito",
+        "checkCreditsFailedRetry": "Falha ao verificar os requisitos de crédito. Tente novamente.",
+        "insufficientCredits": "Créditos insuficientes para esta edição",
+        "updateImageFailed": "Falha ao atualizar a imagem. Tente novamente."
+      },
+      "imageSave": {
+        "title": "A guardar alterações na imagem",
+        "description": "Por favor aguarde enquanto guardamos as alterações de imagem na história..."
       }
     },
     "creditConfirmation": {


### PR DESCRIPTION
## Summary
- add missing localization keys for AIEditModal in both EN and PT messages
- replace hard coded strings in `AIEditModal` with `t()` lookups

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688ca3eb6d308328858e4705f07db534