### PR TITLE
Add translation keys for image editor and progress modal

### DIFF
--- a/src/components/AIImageEditor.tsx
+++ b/src/components/AIImageEditor.tsx
@@ -338,13 +338,13 @@ export default function AIImageEditor({
             {newImageGenerated && (
               <div className="space-y-3">
                 <label className="block text-sm font-medium text-gray-700">
-                  New Generated Image
+                  {t('newImageLabel')}
                 </label>
                 <div className="bg-green-50 rounded-lg p-4 border border-green-200">
                   <div className="relative mx-auto max-w-sm">
                     <Image
                       src={toAbsoluteImageUrl(newImageGenerated) || ''}
-                      alt="Generated Image"
+                      alt={t('generatedImageAlt')}
                       width={400}
                       height={500}
                       className="w-full h-auto rounded-lg object-cover"
@@ -352,7 +352,7 @@ export default function AIImageEditor({
                   </div>
                   <div className="mt-4 text-center">
                     <p className="text-sm text-green-600 mb-3">
-                      New image generated successfully!
+                      {t('newImageSuccess')}
                     </p>
                     <button
                       onClick={handleReplaceImage}

--- a/src/components/JobProgressModal.tsx
+++ b/src/components/JobProgressModal.tsx
@@ -226,7 +226,7 @@ export default function JobProgressModal({
           {/* Progress Bar */}
           <div className="space-y-3">
             <div className="flex justify-between text-sm text-gray-600">
-              <span>Progress</span>
+              <span>{t('labels.progress')}</span>
               <span>{Math.round(jobStatus?.progress || 0)}%</span>
             </div>
             <div className="w-full bg-gray-200 rounded-full h-2">
@@ -247,9 +247,13 @@ export default function JobProgressModal({
           {jobStatus && jobStatus.status === 'processing' && (
             <div className="mt-4 space-y-2">
               <div className="flex justify-between text-xs text-gray-500">
-                <span>Elapsed: {formatTime(jobStatus.elapsedTime)}</span>
                 <span>
-                  Remaining: ~{formatTime(Math.max(0, jobStatus.remainingTime))}
+                  {t('labels.elapsed')}: {formatTime(jobStatus.elapsedTime)}
+                </span>
+                <span>
+                  {t('labels.remaining')}: ~{formatTime(
+                    Math.max(0, jobStatus.remainingTime)
+                  )}
                 </span>
               </div>
             </div>
@@ -271,7 +275,7 @@ export default function JobProgressModal({
               <div className="flex items-center space-x-2">
                 <FiCheckCircle className="w-4 h-4 text-green-600 flex-shrink-0" />
                 <span className="text-sm text-green-600">
-                  Operation completed successfully!
+                  {t('status.completed')}
                 </span>
               </div>
             </div>
@@ -285,7 +289,7 @@ export default function JobProgressModal({
               onClick={onClose}
               className="px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors"
             >
-              Close
+              {t('closeButton')}
             </button>
           </div>
         )}

--- a/src/messages/en-US/components.json
+++ b/src/messages/en-US/components.json
@@ -9,6 +9,9 @@
       "replaceButton": "Replace Original",
       "cancelButton": "Cancel",
       "loading": "Generating...",
+      "newImageLabel": "New Generated Image",
+      "newImageSuccess": "New image generated successfully!",
+      "generatedImageAlt": "Generated Image",
       "errors": {
         "describeChanges": "Please describe the changes you want to make to the image",
         "unableToCheckCredits": "Unable to check credits. Please try again.",
@@ -161,7 +164,13 @@
         "inProgress": "In progress...",
         "completed": "Completed successfully!",
         "failed": "Failed"
-      }
+      },
+      "labels": {
+        "progress": "Progress",
+        "elapsed": "Elapsed",
+        "remaining": "Remaining"
+      },
+      "closeButton": "Close"
     },
     "readingProgress": {
       "fallbacks": {

--- a/src/messages/pt-PT/components.json
+++ b/src/messages/pt-PT/components.json
@@ -9,6 +9,9 @@
       "replaceButton": "Substituir Original",
       "cancelButton": "Cancelar",
       "loading": "A gerar...",
+      "newImageLabel": "Nova Imagem Gerada",
+      "newImageSuccess": "Nova imagem gerada com sucesso!",
+      "generatedImageAlt": "Imagem Gerada",
       "errors": {
         "describeChanges": "Por favor descreva as alterações que quer fazer à imagem",
         "unableToCheckCredits": "Não foi possível verificar os créditos. Tente novamente.",
@@ -161,7 +164,13 @@
         "inProgress": "Em progresso...",
         "completed": "Concluído com sucesso!",
         "failed": "Falhado"
-      }
+      },
+      "labels": {
+        "progress": "Progresso",
+        "elapsed": "Decorrido",
+        "remaining": "Restante"
+      },
+      "closeButton": "Fechar"
     },
     "readingProgress": {
       "fallbacks": {


### PR DESCRIPTION
## Summary
- add labels for new image status
- localize progress modal labels and close button
- use `useTranslations` for new messages in `AIImageEditor` and `JobProgressModal`

## Testing
- `npm run lint`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_688ca3f2993c832894856b1350cec536