### PR TITLE
Refactor estimate time helper to use i18n

### DIFF
--- a/src/components/AudiobookGenerationProgress.tsx
+++ b/src/components/AudiobookGenerationProgress.tsx
@@ -24,17 +24,26 @@ const getFunnyMessage = (step: string, t: ReturnType<typeof import('next-intl').
   return messages[Math.floor(Math.random() * messages.length)];
 };
 
-const calculateEstimatedTime = (percentage: number): string => {
+const calculateEstimatedTime = (
+  percentage: number,
+  t: ReturnType<typeof import('next-intl').useTranslations>
+): string => {
   const totalEstimatedTime = 8 * 60; // 8 minutes in seconds (typically faster than story generation)
-  const remainingTime = Math.max(0, totalEstimatedTime - (totalEstimatedTime * percentage / 100));
-  
+  const remainingTime = Math.max(0, totalEstimatedTime - (totalEstimatedTime * percentage) / 100);
+
   if (remainingTime < 60) {
-    return `${Math.ceil(remainingTime)} seconds`;
-  } else {
-    const minutes = Math.floor(remainingTime / 60);
-    const seconds = Math.ceil(remainingTime % 60);
-    return seconds > 0 ? `${minutes}:${seconds.toString().padStart(2, '0')} minutes` : `${minutes} minutes`;
+    const value = Math.ceil(remainingTime);
+    const unit = value === 1 ? t('timeUnits.second') : t('timeUnits.seconds');
+    return `${value} ${unit}`;
   }
+
+  const minutes = Math.floor(remainingTime / 60);
+  const seconds = Math.ceil(remainingTime % 60);
+  const minuteLabel = minutes === 1 ? t('timeUnits.minute') : t('timeUnits.minutes');
+
+  return seconds > 0
+    ? `${minutes}:${seconds.toString().padStart(2, '0')} ${minuteLabel}`
+    : `${minutes} ${minuteLabel}`;
 };
 
 export default function AudiobookGenerationProgress({ storyId, onComplete }: AudiobookGenerationProgressProps) {
@@ -173,7 +182,7 @@ export default function AudiobookGenerationProgress({ storyId, onComplete }: Aud
           max={100}
         />
         <div className="flex justify-between items-center mt-2 text-xs text-gray-500">
-          <span>{t('estimatedTimeRemaining')}: {calculateEstimatedTime(progress.audiobookGenerationCompletedPercentage)}</span>
+          <span>{t('estimatedTimeRemaining')}: {calculateEstimatedTime(progress.audiobookGenerationCompletedPercentage, t)}</span>
           {progress.chaptersProcessed && progress.totalChapters && (
             <span>{t('chaptersProcessed', { 
               processed: progress.chaptersProcessed, 

--- a/src/components/StoryGenerationProgress.tsx
+++ b/src/components/StoryGenerationProgress.tsx
@@ -23,17 +23,26 @@ const getFunnyMessage = (step: string, t: ReturnType<typeof import('next-intl').
   return messages[Math.floor(Math.random() * messages.length)];
 };
 
-const calculateEstimatedTime = (percentage: number): string => {
+const calculateEstimatedTime = (
+  percentage: number,
+  t: ReturnType<typeof import('next-intl').useTranslations>
+): string => {
   const totalEstimatedTime = 14 * 60; // 14 minutes in seconds
-  const remainingTime = Math.max(0, totalEstimatedTime - (totalEstimatedTime * percentage / 100));
-  
+  const remainingTime = Math.max(0, totalEstimatedTime - (totalEstimatedTime * percentage) / 100);
+
   if (remainingTime < 60) {
-    return `${Math.ceil(remainingTime)} seconds`;
-  } else {
-    const minutes = Math.floor(remainingTime / 60);
-    const seconds = Math.ceil(remainingTime % 60);
-    return seconds > 0 ? `${minutes}:${seconds.toString().padStart(2, '0')} minutes` : `${minutes} minutes`;
+    const value = Math.ceil(remainingTime);
+    const unit = value === 1 ? t('timeUnits.second') : t('timeUnits.seconds');
+    return `${value} ${unit}`;
   }
+
+  const minutes = Math.floor(remainingTime / 60);
+  const seconds = Math.ceil(remainingTime % 60);
+  const minuteLabel = minutes === 1 ? t('timeUnits.minute') : t('timeUnits.minutes');
+
+  return seconds > 0
+    ? `${minutes}:${seconds.toString().padStart(2, '0')} ${minuteLabel}`
+    : `${minutes} ${minuteLabel}`;
 };
 
 export default function StoryGenerationProgress({ storyId, onComplete }: StoryGenerationProgressProps) {
@@ -110,7 +119,7 @@ export default function StoryGenerationProgress({ storyId, onComplete }: StoryGe
     return () => clearInterval(intervalId);
   }, [storyId, onComplete]);
   const percentage = progress.storyGenerationCompletedPercentage;
-  const estimatedTime = calculateEstimatedTime(percentage);
+  const estimatedTime = calculateEstimatedTime(percentage, t);
   const isCompleted = progress.status === 'published';
 
   // Show completion state when story is published

--- a/src/messages/en-US/common.json
+++ b/src/messages/en-US/common.json
@@ -252,10 +252,12 @@
 			},
 			"StoryGenerationProgress": {
 				"ready": "Your Story is Ready!",
-				"timeUnits": {
-					"seconds": "seconds",
-					"minutes": "minutes"
-				}
+                                "timeUnits": {
+                                        "second": "second",
+                                        "seconds": "seconds",
+                                        "minute": "minute",
+                                        "minutes": "minutes"
+                                }
 			},
 			"MyStoriesTable": {
 				"generationStatus": {

--- a/src/messages/en-US/components.json
+++ b/src/messages/en-US/components.json
@@ -46,6 +46,12 @@
       "errors": {
         "failedToFetch": "Failed to fetch audiobook progress",
         "failedToLoad": "Failed to load audiobook generation progress"
+      },
+      "timeUnits": {
+        "second": "second",
+        "seconds": "seconds",
+        "minute": "minute",
+        "minutes": "minutes"
       }
     },
     "audiobookGenerationTrigger": {

--- a/src/messages/pt-PT/common.json
+++ b/src/messages/pt-PT/common.json
@@ -253,7 +253,9 @@
       "StoryGenerationProgress": {
         "ready": "A Sua História Está Pronta!",
         "timeUnits": {
+          "second": "segundo",
           "seconds": "segundos",
+          "minute": "minuto",
           "minutes": "minutos"
         }
       },

--- a/src/messages/pt-PT/components.json
+++ b/src/messages/pt-PT/components.json
@@ -46,6 +46,12 @@
       "errors": {
         "failedToFetch": "Falha ao obter progresso do audiolivro",
         "failedToLoad": "Falha ao carregar progresso da geração do audiolivro"
+      },
+      "timeUnits": {
+        "second": "segundo",
+        "seconds": "segundos",
+        "minute": "minuto",
+        "minutes": "minutos"
       }
     },
     "audiobookGenerationTrigger": {


### PR DESCRIPTION
## Summary
- localize estimated time units in progress components
- add singular and plural labels for time units in translations
- refactor `calculateEstimatedTime` to build strings via `t()`

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688ca40f36a0832899f3df833a3ea42c