### PR TITLE
Add localized voice names and error message

### DIFF
--- a/src/app/[locale]/stories/listen/[storyId]/page.tsx
+++ b/src/app/[locale]/stories/listen/[storyId]/page.tsx
@@ -135,17 +135,17 @@ export default function ListenStoryPage() {
 
   // Voice options for narration
   const voiceOptions = [
-    { value: 'alloy', label: 'Alloy' },
-    { value: 'ash', label: 'Ash' },
-    { value: 'ballad', label: 'Ballad' },
-    { value: 'coral', label: 'Coral' },
-    { value: 'echo', label: 'Echo' },
-    { value: 'fable', label: 'Fable' },
-    { value: 'nova', label: 'Nova' },
-    { value: 'onyx', label: 'Onyx' },
-    { value: 'sage', label: 'Sage' },
-    { value: 'shimmer', label: 'Shimmer' },
-    { value: 'verse', label: 'Verse' }
+    { value: 'alloy', label: tCommon('voices.names.alloy') },
+    { value: 'ash', label: tCommon('voices.names.ash') },
+    { value: 'ballad', label: tCommon('voices.names.ballad') },
+    { value: 'coral', label: tCommon('voices.names.coral') },
+    { value: 'echo', label: tCommon('voices.names.echo') },
+    { value: 'fable', label: tCommon('voices.names.fable') },
+    { value: 'nova', label: tCommon('voices.names.nova') },
+    { value: 'onyx', label: tCommon('voices.names.onyx') },
+    { value: 'sage', label: tCommon('voices.names.sage') },
+    { value: 'shimmer', label: tCommon('voices.names.shimmer') },
+    { value: 'verse', label: tCommon('voices.names.verse') },
   ];
 
   useEffect(() => {

--- a/src/components/AudiobookGenerationTrigger.tsx
+++ b/src/components/AudiobookGenerationTrigger.tsx
@@ -20,6 +20,7 @@ export default function AudiobookGenerationTrigger({
   onGenerationComplete
 }: AudiobookGenerationTriggerProps) {
   const t = useTranslations('components.audiobookGenerationTrigger');
+  const tCommon = useTranslations('common');
   const [isGeneratingLocal, setIsGeneratingLocal] = useState(isGenerating);
   const [error, setError] = useState<string | null>(null);
   const [selectedVoice, setSelectedVoice] = useState('nova');
@@ -56,7 +57,9 @@ export default function AudiobookGenerationTrigger({
       
     } catch (error) {
       console.error('Error generating audiobook:', error);
-      setError(error instanceof Error ? error.message : 'Failed to generate audiobook');
+      setError(
+        error instanceof Error ? error.message : t('errors.failedToStart'),
+      );
       setIsGeneratingLocal(false);
     }
   };
@@ -70,12 +73,36 @@ export default function AudiobookGenerationTrigger({
 
   // Voice options for OpenAI TTS
   const voiceOptions = [
-    { value: 'alloy', label: 'Alloy', description: 'Neutral, balanced voice' },
-    { value: 'echo', label: 'Echo', description: 'Clear, expressive voice' },
-    { value: 'fable', label: 'Fable', description: 'Warm, storytelling voice' },
-    { value: 'nova', label: 'Nova', description: 'Bright, energetic voice' },
-    { value: 'onyx', label: 'Onyx', description: 'Deep, authoritative voice' },
-    { value: 'shimmer', label: 'Shimmer', description: 'Gentle, soothing voice' },
+    {
+      value: 'alloy',
+      label: tCommon('voices.names.alloy'),
+      description: tCommon('voices.descriptions.alloy'),
+    },
+    {
+      value: 'echo',
+      label: tCommon('voices.names.echo'),
+      description: tCommon('voices.descriptions.echo'),
+    },
+    {
+      value: 'fable',
+      label: tCommon('voices.names.fable'),
+      description: tCommon('voices.descriptions.fable'),
+    },
+    {
+      value: 'nova',
+      label: tCommon('voices.names.nova'),
+      description: tCommon('voices.descriptions.nova'),
+    },
+    {
+      value: 'onyx',
+      label: tCommon('voices.names.onyx'),
+      description: tCommon('voices.descriptions.onyx'),
+    },
+    {
+      value: 'shimmer',
+      label: tCommon('voices.names.shimmer'),
+      description: tCommon('voices.descriptions.shimmer'),
+    },
   ];
 
   if (hasAudiobook) {

--- a/src/messages/en-US/common.json
+++ b/src/messages/en-US/common.json
@@ -753,12 +753,25 @@
 			},
 			"quote": "\"Not all those who wander are lost... but this page definitely is!\" - A confused Hobbit"
 		},
-		"voices": {
-			"selectVoice": "Select Voice",
-			"descriptions": {
-				"alloy": "A neutral and balanced voice suited for general narration and information delivery.",
-				"ash": "A clear and precise voice, ideal for instructions and technical explanations.",
-				"ballad": "A melodic and smooth voice that lends itself well to storytelling and narrative content.",
+                "voices": {
+                        "selectVoice": "Select Voice",
+                        "names": {
+                                "alloy": "Alloy",
+                                "ash": "Ash",
+                                "ballad": "Ballad",
+                                "coral": "Coral",
+                                "echo": "Echo",
+                                "fable": "Fable",
+                                "nova": "Nova",
+                                "onyx": "Onyx",
+                                "sage": "Sage",
+                                "shimmer": "Shimmer",
+                                "verse": "Verse"
+                        },
+                        "descriptions": {
+                                "alloy": "A neutral and balanced voice suited for general narration and information delivery.",
+                                "ash": "A clear and precise voice, ideal for instructions and technical explanations.",
+                                "ballad": "A melodic and smooth voice that lends itself well to storytelling and narrative content.",
 				"coral": "A warm and friendly voice, perfect for conversational interfaces and customer-facing dialogue.",
 				"echo": "A resonant and deep voice, offering a strong presence for announcements and formal messages.",
 				"fable": "A warm and engaging voice with a storytelling quality, designed for immersive narratives.",

--- a/src/messages/pt-PT/common.json
+++ b/src/messages/pt-PT/common.json
@@ -627,6 +627,19 @@
     },
     "voices": {
       "selectVoice": "Selecionar Voz",
+      "names": {
+        "alloy": "Alloy",
+        "ash": "Ash",
+        "ballad": "Ballad",
+        "coral": "Coral",
+        "echo": "Echo",
+        "fable": "Fable",
+        "nova": "Nova",
+        "onyx": "Onyx",
+        "sage": "Sage",
+        "shimmer": "Shimmer",
+        "verse": "Verse"
+      },
       "descriptions": {
         "alloy": "Uma voz neutra e equilibrada adequada para narração geral e entrega de informação.",
         "ash": "Uma voz clara e precisa, ideal para instruções e explicações técnicas.",


### PR DESCRIPTION
## Summary
- translate voice names for EN/PT locales
- use localized voice names in story listener and audiobook generator
- fall back to a translated error when generation fails

## Testing
- `npm run lint`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_688ca415c06c8328b5261de863d49a0f