### PR TITLE
Add i18n for job progress modal

### DIFF
--- a/src/components/JobProgressModal.tsx
+++ b/src/components/JobProgressModal.tsx
@@ -226,7 +226,7 @@ export default function JobProgressModal({
           {/* Progress Bar */}
           <div className="space-y-3">
             <div className="flex justify-between text-sm text-gray-600">
-              <span>Progress</span>
+              <span>{t('progressLabel')}</span>
               <span>{Math.round(jobStatus?.progress || 0)}%</span>
             </div>
             <div className="w-full bg-gray-200 rounded-full h-2">
@@ -247,9 +247,12 @@ export default function JobProgressModal({
           {jobStatus && jobStatus.status === 'processing' && (
             <div className="mt-4 space-y-2">
               <div className="flex justify-between text-xs text-gray-500">
-                <span>Elapsed: {formatTime(jobStatus.elapsedTime)}</span>
                 <span>
-                  Remaining: ~{formatTime(Math.max(0, jobStatus.remainingTime))}
+                  {t('elapsedLabel')}: {formatTime(jobStatus.elapsedTime)}
+                </span>
+                <span>
+                  {t('remainingLabel')}: ~
+                  {formatTime(Math.max(0, jobStatus.remainingTime))}
                 </span>
               </div>
             </div>
@@ -271,7 +274,7 @@ export default function JobProgressModal({
               <div className="flex items-center space-x-2">
                 <FiCheckCircle className="w-4 h-4 text-green-600 flex-shrink-0" />
                 <span className="text-sm text-green-600">
-                  Operation completed successfully!
+                  {t('successMessage')}
                 </span>
               </div>
             </div>
@@ -285,7 +288,7 @@ export default function JobProgressModal({
               onClick={onClose}
               className="px-4 py-2 bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors"
             >
-              Close
+              {t('close')}
             </button>
           </div>
         )}

--- a/src/messages/en-US/components.json
+++ b/src/messages/en-US/components.json
@@ -161,7 +161,12 @@
         "inProgress": "In progress...",
         "completed": "Completed successfully!",
         "failed": "Failed"
-      }
+      },
+      "progressLabel": "Progress",
+      "elapsedLabel": "Elapsed",
+      "remainingLabel": "Remaining",
+      "successMessage": "Operation completed successfully!",
+      "close": "Close"
     },
     "readingProgress": {
       "fallbacks": {

--- a/src/messages/pt-PT/components.json
+++ b/src/messages/pt-PT/components.json
@@ -161,7 +161,12 @@
         "inProgress": "Em progresso...",
         "completed": "Concluído com sucesso!",
         "failed": "Falhado"
-      }
+      },
+      "progressLabel": "Progresso",
+      "elapsedLabel": "Tempo decorrido",
+      "remainingLabel": "Tempo restante",
+      "successMessage": "Operação concluída com sucesso!",
+      "close": "Fechar"
     },
     "readingProgress": {
       "fallbacks": {


### PR DESCRIPTION
## Summary
- add more translation keys to job progress modal
- use `t()` helper throughout modal

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ca431a79c83288f8e68acc37bb69b