### PR TITLE
feat(i18n): localize generation status labels

### DIFF
--- a/src/components/MyStoriesTable.tsx
+++ b/src/components/MyStoriesTable.tsx
@@ -227,11 +227,11 @@ export default function MyStoriesTable() {
     }
 
     const statusMap = {
-      'queued': { text: 'Queued', class: 'badge-info', icon: '⏳' },
-      'running': { text: 'Generating', class: 'badge-warning', icon: '🔄' },
-      'completed': { text: 'Completed', class: 'badge-success', icon: '✅' },
-      'failed': { text: 'Failed', class: 'badge-error', icon: '❌' },
-      'cancelled': { text: 'Cancelled', class: 'badge-neutral', icon: '⏹️' },
+      queued: { text: t('table.status.queued'), class: 'badge-info', icon: '⏳' },
+      running: { text: t('table.status.running'), class: 'badge-warning', icon: '🔄' },
+      completed: { text: t('table.status.completed'), class: 'badge-success', icon: '✅' },
+      failed: { text: t('table.status.failed'), class: 'badge-error', icon: '❌' },
+      cancelled: { text: t('table.status.cancelled'), class: 'badge-neutral', icon: '⏹️' },
     };
 
     const statusInfo = statusMap[story.storyGenerationStatus];
@@ -293,7 +293,7 @@ export default function MyStoriesTable() {
                       className="btn btn-ghost btn-sm p-0 h-auto font-medium text-left justify-start"
                       onClick={() => handleSort('status')}
                     >
-                      {t('table.status')}
+                      {t('table.status.header')}
                       {getSortIcon('status')}
                     </button>
                   </th>

--- a/src/messages/en-US/MyStoriesPage.json
+++ b/src/messages/en-US/MyStoriesPage.json
@@ -9,8 +9,15 @@
   },
   "table": {
     "date": "Date",
-    "title": "Title", 
-    "status": "Status",
+    "title": "Title",
+    "status": {
+      "header": "Status",
+      "queued": "Queued",
+      "running": "Generating",
+      "completed": "Completed",
+      "failed": "Failed",
+      "cancelled": "Cancelled"
+    },
     "actions": "Actions"
   },
   "status": {

--- a/src/messages/pt-PT/MyStoriesPage.json
+++ b/src/messages/pt-PT/MyStoriesPage.json
@@ -9,8 +9,15 @@
   },
   "table": {
     "date": "Data",
-    "title": "Título", 
-    "status": "Estado",
+    "title": "Título",
+    "status": {
+      "header": "Estado",
+      "queued": "Em Fila",
+      "running": "A Gerar",
+      "completed": "Concluída",
+      "failed": "Falhada",
+      "cancelled": "Cancelada"
+    },
     "actions": "Ações"
   },
   "status": {


### PR DESCRIPTION
## Summary
- add generation status labels under `table.status` in `MyStoriesPage` locales
- update table header path and map status labels with `t()`

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688ca43bb2d083289dd5e76137572f07