### PR TITLE
Update ShareModal i18n

### DIFF
--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -61,7 +61,7 @@ export default function ShareModal({ isOpen, onClose, storyId, storyTitle, isPub
 
       if (!storyId || storyId === 'undefined') {
         console.error('Invalid storyId:', storyId);
-        alert('Invalid story ID');
+        alert(t('alerts.invalidStoryId'));
         setLoading(false);
         return;
       }
@@ -130,7 +130,7 @@ export default function ShareModal({ isOpen, onClose, storyId, storyTitle, isPub
   const handleNativeShare = async (url: string) => {
     const sharePayload = {
       title: storyTitle,
-      text: `Check out "${storyTitle}" on Mythoria 📚`,
+      text: t('shareMessages.checkOut', { storyTitle }),
       url,
     };
 
@@ -147,19 +147,19 @@ export default function ShareModal({ isOpen, onClose, storyId, storyTitle, isPub
   };
 
   const handleWhatsApp = (url: string) => {
-    const message = encodeURIComponent(`Check out "${storyTitle}" on Mythoria 📚 ${url}`);
+    const message = encodeURIComponent(`${t('shareMessages.checkOut', { storyTitle })} ${url}`);
     window.open(`https://wa.me/?text=${message}`, '_blank');
   };
 
   const handleFacebook = (url: string) => {
     const encodedUrl = encodeURIComponent(url);
-    const message = encodeURIComponent(`Check out "${storyTitle}" on Mythoria 📚`);
+    const message = encodeURIComponent(t('shareMessages.checkOut', { storyTitle }));
     window.open(`https://www.facebook.com/dialog/share?app_id=YOUR_APP_ID&href=${encodedUrl}&quote=${message}`, '_blank');
   };
 
   const handleEmail = (url: string) => {
-    const subject = encodeURIComponent(`Check out "${storyTitle}"`);
-    const body = encodeURIComponent(`I wanted to share this story with you:\n\n"${storyTitle}"\n\n${url}\n\nEnjoy reading! 📚`);
+    const subject = encodeURIComponent(t('shareMessages.emailSubject', { storyTitle }));
+    const body = encodeURIComponent(t('shareMessages.emailBody', { storyTitle, url }));
     window.open(`mailto:?subject=${subject}&body=${body}`, '_blank');
   };
   const reset = () => {

--- a/src/messages/en-US/common.json
+++ b/src/messages/en-US/common.json
@@ -174,12 +174,20 @@
 				"publicStoryTitle": "Public Story",
 				"publicStoryDesc": "This story is currently public and can be viewed by anyone.",
 				"publicUrl": "Public URL",
-				"makePrivate": "Make story private",
-				"makePrivateDesc": "Remove public access and make the story private",
-				"errors": {
-					"createLinkFailed": "Error creating share link: Please try again later.",
-					"shareLinkCreationFailed": "Failed to create share link. Please try again."
-				}
+        "makePrivate": "Make story private",
+        "makePrivateDesc": "Remove public access and make the story private",
+        "errors": {
+            "createLinkFailed": "Error creating share link: Please try again later.",
+            "shareLinkCreationFailed": "Failed to create share link. Please try again."
+        },
+        "alerts": {
+            "invalidStoryId": "Invalid story ID"
+        },
+        "shareMessages": {
+            "checkOut": "Check out \"{storyTitle}\" on Mythoria \ud83d\udcda",
+            "emailSubject": "Check out \"{storyTitle}\"",
+            "emailBody": "I wanted to share this story with you:\n\n\"{storyTitle}\"\n\n{url}\n\nEnjoy reading! \ud83d\udcda"
+        }
 			},
 			"CreditsDisplay": {
 				"button": "Credits available: {credits}",

--- a/src/messages/pt-PT/common.json
+++ b/src/messages/pt-PT/common.json
@@ -179,6 +179,14 @@
         "errors": {
           "createLinkFailed": "Erro ao criar link de partilha: Tente novamente mais tarde.",
           "shareLinkCreationFailed": "Falha ao criar ligação de partilha. Por favor tente novamente."
+        },
+        "alerts": {
+          "invalidStoryId": "ID de história inválido"
+        },
+        "shareMessages": {
+          "checkOut": "Veja \"{storyTitle}\" no Mythoria \ud83d\udcda",
+          "emailSubject": "Veja \"{storyTitle}\"",
+          "emailBody": "Queria partilhar esta história consigo:\n\n\"{storyTitle}\"\n\n{url}\n\nBoa leitura! \ud83d\udcda"
         }
       },
       "CreditsDisplay": {


### PR DESCRIPTION
## Summary
- add translation keys for ShareModal alerts and share templates in English & Portuguese
- reference new translations inside ShareModal

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688ca45301f88328ad55e38519b55241