### PR TITLE
Add i18n units for progress timers

### DIFF
--- a/src/components/AudiobookGenerationProgress.tsx
+++ b/src/components/AudiobookGenerationProgress.tsx
@@ -18,22 +18,27 @@ interface AudiobookProgress {
   totalChapters?: number;
 }
 
+interface TimeUnits {
+  seconds: string;
+  minutes: string;
+}
+
 // Funny narrator messages based on current step
 const getFunnyMessage = (step: string, t: ReturnType<typeof import('next-intl').useTranslations>) => {
   const messages = t.raw(`narrationMessages.${step}`) || t.raw('narrationMessages.default');
   return messages[Math.floor(Math.random() * messages.length)];
 };
 
-const calculateEstimatedTime = (percentage: number): string => {
+const calculateEstimatedTime = (percentage: number, timeUnits: TimeUnits): string => {
   const totalEstimatedTime = 8 * 60; // 8 minutes in seconds (typically faster than story generation)
   const remainingTime = Math.max(0, totalEstimatedTime - (totalEstimatedTime * percentage / 100));
-  
+
   if (remainingTime < 60) {
-    return `${Math.ceil(remainingTime)} seconds`;
+    return `${Math.ceil(remainingTime)} ${timeUnits.seconds}`;
   } else {
     const minutes = Math.floor(remainingTime / 60);
     const seconds = Math.ceil(remainingTime % 60);
-    return seconds > 0 ? `${minutes}:${seconds.toString().padStart(2, '0')} minutes` : `${minutes} minutes`;
+    return seconds > 0 ? `${minutes}:${seconds.toString().padStart(2, '0')} ${timeUnits.minutes}` : `${minutes} ${timeUnits.minutes}`;
   }
 };
 
@@ -173,7 +178,10 @@ export default function AudiobookGenerationProgress({ storyId, onComplete }: Aud
           max={100}
         />
         <div className="flex justify-between items-center mt-2 text-xs text-gray-500">
-          <span>{t('estimatedTimeRemaining')}: {calculateEstimatedTime(progress.audiobookGenerationCompletedPercentage)}</span>
+          <span>{t('estimatedTimeRemaining')}: {calculateEstimatedTime(progress.audiobookGenerationCompletedPercentage, {
+            seconds: t('timeUnits.seconds'),
+            minutes: t('timeUnits.minutes'),
+          })}</span>
           {progress.chaptersProcessed && progress.totalChapters && (
             <span>{t('chaptersProcessed', { 
               processed: progress.chaptersProcessed, 

--- a/src/components/StoryGenerationProgress.tsx
+++ b/src/components/StoryGenerationProgress.tsx
@@ -23,16 +23,21 @@ const getFunnyMessage = (step: string, t: ReturnType<typeof import('next-intl').
   return messages[Math.floor(Math.random() * messages.length)];
 };
 
-const calculateEstimatedTime = (percentage: number): string => {
+interface TimeUnits {
+  seconds: string;
+  minutes: string;
+}
+
+const calculateEstimatedTime = (percentage: number, timeUnits: TimeUnits): string => {
   const totalEstimatedTime = 14 * 60; // 14 minutes in seconds
   const remainingTime = Math.max(0, totalEstimatedTime - (totalEstimatedTime * percentage / 100));
-  
+
   if (remainingTime < 60) {
-    return `${Math.ceil(remainingTime)} seconds`;
+    return `${Math.ceil(remainingTime)} ${timeUnits.seconds}`;
   } else {
     const minutes = Math.floor(remainingTime / 60);
     const seconds = Math.ceil(remainingTime % 60);
-    return seconds > 0 ? `${minutes}:${seconds.toString().padStart(2, '0')} minutes` : `${minutes} minutes`;
+    return seconds > 0 ? `${minutes}:${seconds.toString().padStart(2, '0')} ${timeUnits.minutes}` : `${minutes} ${timeUnits.minutes}`;
   }
 };
 
@@ -110,7 +115,10 @@ export default function StoryGenerationProgress({ storyId, onComplete }: StoryGe
     return () => clearInterval(intervalId);
   }, [storyId, onComplete]);
   const percentage = progress.storyGenerationCompletedPercentage;
-  const estimatedTime = calculateEstimatedTime(percentage);
+  const estimatedTime = calculateEstimatedTime(percentage, {
+    seconds: t('timeUnits.seconds'),
+    minutes: t('timeUnits.minutes'),
+  });
   const isCompleted = progress.status === 'published';
 
   // Show completion state when story is published

--- a/src/messages/en-US/common.json
+++ b/src/messages/en-US/common.json
@@ -648,8 +648,12 @@
 			"notAvailable": "N/A",
 			"description": "stories created and counting..."
 		},
-		"storyGenerationProgress": {
-			"completion": {
+                "storyGenerationProgress": {
+                        "timeUnits": {
+                                "seconds": "seconds",
+                                "minutes": "minutes"
+                        },
+                        "completion": {
 				"title": "Your Story is Ready!",
 				"description": "Congratulations! Your magical story has been created and is ready to be read.",
 				"progress": "100% Complete!",

--- a/src/messages/en-US/components.json
+++ b/src/messages/en-US/components.json
@@ -46,6 +46,10 @@
       "errors": {
         "failedToFetch": "Failed to fetch audiobook progress",
         "failedToLoad": "Failed to load audiobook generation progress"
+      },
+      "timeUnits": {
+        "seconds": "seconds",
+        "minutes": "minutes"
       }
     },
     "audiobookGenerationTrigger": {

--- a/src/messages/pt-PT/common.json
+++ b/src/messages/pt-PT/common.json
@@ -521,6 +521,10 @@
       "description": "histórias criadas e contando..."
     },
     "storyGenerationProgress": {
+      "timeUnits": {
+        "seconds": "segundos",
+        "minutes": "minutos"
+      },
       "completion": {
         "title": "A Sua História Está Pronta!",
         "description": "Parabéns! A sua história mágica foi criada e está pronta para ser lida.",

--- a/src/messages/pt-PT/components.json
+++ b/src/messages/pt-PT/components.json
@@ -46,6 +46,10 @@
       "errors": {
         "failedToFetch": "Falha ao obter progresso do audiolivro",
         "failedToLoad": "Falha ao carregar progresso da geração do audiolivro"
+      },
+      "timeUnits": {
+        "seconds": "segundos",
+        "minutes": "minutos"
       }
     },
     "audiobookGenerationTrigger": {


### PR DESCRIPTION
## Summary
- localize time units for progress components
- wire progress indicators to translated time units

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_688ca45814b083288d8a90ec3ffd30b6