### PR TITLE
Handle pricing and credit fetch errors

### DIFF
--- a/src/components/print-order/steps/PaymentStep.tsx
+++ b/src/components/print-order/steps/PaymentStep.tsx
@@ -115,7 +115,7 @@ export default function PaymentStep({
       setPrintingOptions(options);
     } catch (error) {
       console.error('Error fetching printing options:', error);
-      throw error;
+      setError(t('errors.loadPricingFailed'));
     }
   }, [t]);
 
@@ -129,22 +129,14 @@ export default function PaymentStep({
       setUserCredits(data.currentBalance || 0);
     } catch (error) {
       console.error('Error fetching user credits:', error);
-      throw error;
+      setError(t('errors.fetchCreditsFailed'));
     }
-  }, []);
+  }, [t]);
   useEffect(() => {
     const fetchData = async () => {
-      try {
-        await Promise.all([
-          fetchPrintingOptions(),
-          fetchUserCredits()
-        ]);
-      } catch (err) {
-        console.error('Error fetching data:', err);
-        setError('Failed to load pricing information');
-      } finally {
-        setLoadingData(false);
-      }
+      await fetchPrintingOptions();
+      await fetchUserCredits();
+      setLoadingData(false);
     };
 
     fetchData();

--- a/src/messages/en-US/publicPages.json
+++ b/src/messages/en-US/publicPages.json
@@ -460,7 +460,9 @@
       "loadingFailed": "Failed to load story data",
       "missingRequiredFields": "Please complete all required fields",
       "orderFailed": "Failed to place print order",
-      "insufficientCredits": "Insufficient credits."
+      "insufficientCredits": "Insufficient credits.",
+      "loadPricingFailed": "Failed to load pricing information",
+      "fetchCreditsFailed": "Failed to fetch credit balance"
     },
     "addressInfo": {
       "selectShipping": "Please select a shipping address for your printed book.",

--- a/src/messages/pt-PT/publicPages.json
+++ b/src/messages/pt-PT/publicPages.json
@@ -480,7 +480,9 @@
       "loadingFailed": "Falha ao carregar dados da história",
       "missingRequiredFields": "Por favor complete todos os campos obrigatórios",
       "orderFailed": "Falha ao efetuar encomenda de impressão",
-      "insufficientCredits": "Créditos insuficientes."
+      "insufficientCredits": "Créditos insuficientes.",
+      "loadPricingFailed": "Falha ao carregar informação de preços",
+      "fetchCreditsFailed": "Falha ao obter saldo de créditos"
     },
     "addressInfo": {
       "selectShipping": "Por favor selecione uma morada de envio para o seu livro impresso.",


### PR DESCRIPTION
## Summary
- handle missing pricing & credit info in the print order payment step
- translate new error messages in EN and PT locales

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688ca45c2f40832898fd72c7482e49ef