### PR TITLE
Localize timeline step labels

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -247,7 +247,7 @@ export default function Home() {
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-5 w-5"><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clipRule="evenodd" /></svg>
                   </div>
                   <div className="timeline-start md:text-end mb-10">
-                    <time className="font-mono italic">Step 1</time>
+                    <time className="font-mono italic">{t('howItWorks.stepLabels.step1')}</time>
                     <div className="text-lg font-black">{t('howItWorks.steps.step1.title')}</div>
                     {t('howItWorks.steps.step1.description')}
                   </div>
@@ -259,7 +259,7 @@ export default function Home() {
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-5 w-5"><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clipRule="evenodd" /></svg>
                   </div>
                   <div className="timeline-end mb-10">
-                    <time className="font-mono italic">Step 2</time>
+                    <time className="font-mono italic">{t('howItWorks.stepLabels.step2')}</time>
                     <div className="text-lg font-black">{t('howItWorks.steps.step2.title')}</div>
                     {t('howItWorks.steps.step2.description')}
                   </div>
@@ -271,7 +271,7 @@ export default function Home() {
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-5 w-5"><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clipRule="evenodd" /></svg>
                   </div>
                   <div className="timeline-start md:text-end mb-10">
-                    <time className="font-mono italic">Step 3</time>
+                    <time className="font-mono italic">{t('howItWorks.stepLabels.step3')}</time>
                     <div className="text-lg font-black">{t('howItWorks.steps.step3.title')}</div>
                     {t('howItWorks.steps.step3.description')}
                   </div>
@@ -283,7 +283,7 @@ export default function Home() {
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-5 w-5"><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clipRule="evenodd" /></svg>
                   </div>
                   <div className="timeline-end mb-10">
-                    <time className="font-mono italic">Step 4</time>
+                    <time className="font-mono italic">{t('howItWorks.stepLabels.step4')}</time>
                     <div className="text-lg font-black">{t('howItWorks.steps.step4.title')}</div>
                     {t('howItWorks.steps.step4.description')}
                   </div>
@@ -295,7 +295,7 @@ export default function Home() {
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-5 w-5"><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clipRule="evenodd" /></svg>
                   </div>
                   <div className="timeline-start md:text-end mb-10">
-                    <time className="font-mono italic">Step 5</time>
+                    <time className="font-mono italic">{t('howItWorks.stepLabels.step5')}</time>
                     <div className="text-lg font-black">{t('howItWorks.steps.step5.title')}</div>
                     {t('howItWorks.steps.step5.description')}
                   </div>
@@ -307,7 +307,7 @@ export default function Home() {
                     <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" className="h-5 w-5"><path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.857-9.809a.75.75 0 00-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 10-1.06 1.061l2.5 2.5a.75.75 0 001.137-.089l4-5.5z" clipRule="evenodd" /></svg>
                   </div>
                   <div className="timeline-end mb-10">
-                    <time className="font-mono italic">Step 6</time>
+                    <time className="font-mono italic">{t('howItWorks.stepLabels.step6')}</time>
                     <div className="text-lg font-black">{t('howItWorks.steps.step6.title')}</div>
                     {t('howItWorks.steps.step6.description')}
                   </div>

--- a/src/messages/en-US/publicPages.json
+++ b/src/messages/en-US/publicPages.json
@@ -185,6 +185,14 @@
           "description": "Children will be captivated seeing themselves in exciting adventures, while adults will be delighted by reliving cherished memories and sharing heartfelt moments."
         }
       },
+      "stepLabels": {
+        "step1": "Step 1",
+        "step2": "Step 2",
+        "step3": "Step 3",
+        "step4": "Step 4",
+        "step5": "Step 5",
+        "step6": "Step 6"
+      },
       "conclusion": "Our Story Factory Oompa-Loompas will handle everything else, bringing your story to life!"
     },
     "community": {

--- a/src/messages/pt-PT/publicPages.json
+++ b/src/messages/pt-PT/publicPages.json
@@ -185,6 +185,14 @@
           "description": "As crianças ficarão cativadas ao verem-se em aventuras emocionantes, enquanto os adultos se deleitam revivendo memórias queridas e partilhando momentos sinceros."
         }
       },
+      "stepLabels": {
+        "step1": "Passo 1",
+        "step2": "Passo 2",
+        "step3": "Passo 3",
+        "step4": "Passo 4",
+        "step5": "Passo 5",
+        "step6": "Passo 6"
+      },
       "conclusion": "Os nossos Umpa-lumpas da Fábrica de Histórias tratam de todo o resto, dando vida à sua história!"
     },
     "community": {


### PR DESCRIPTION
## Summary
- translate home page timeline labels
- add Portuguese translations

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688cc0e50f948328bfe3eb5418c0f4a6