### PR TITLE
Add i18n strings for step2 errors

### DIFF
--- a/src/app/[locale]/tell-your-story/step-2/page.tsx
+++ b/src/app/[locale]/tell-your-story/step-2/page.tsx
@@ -276,7 +276,7 @@ export default function Step2Page() {
       // Get the current authenticated user
       const userResponse = await fetch('/api/auth/me');
       if (!userResponse.ok) {
-        throw new Error('Failed to get user information');
+        throw new Error(t('errors.failedGetUser'));
       }
       const userData = await userResponse.json();
 
@@ -295,7 +295,7 @@ export default function Step2Page() {
 
       if (!response.ok) {
         const errorData = await response.json();
-        throw new Error(errorData.error || 'Failed to create story');
+        throw new Error(errorData.error || t('errors.failedCreate'));
       }
 
       const { story } = await response.json();
@@ -369,7 +369,8 @@ export default function Step2Page() {
 
     } catch (error) {
       console.error('Error creating story:', error);
-      const errorMessage = error instanceof Error ? error.message : 'Unknown error occurred';
+      const errorMessage =
+        error instanceof Error ? error.message : t('errors.unknown');
       alert(t('alerts.failedToCreateStory', { errorMessage }));
     } finally {
       setIsCreatingStory(false);

--- a/src/messages/en-US/storySteps.json
+++ b/src/messages/en-US/storySteps.json
@@ -127,6 +127,11 @@
         "title": "✨ Creating Your Story",
         "message": "Our magical Oompa Loompas are hard at work preparing your story! This might take a moment...",
         "pleaseWait": "Please wait while we work our magic! ✨"
+      },
+      "errors": {
+        "failedGetUser": "Failed to get user information.",
+        "failedCreate": "Failed to create story.",
+        "unknown": "Unknown error occurred."
       }
     },
     "step3": {

--- a/src/messages/pt-PT/storySteps.json
+++ b/src/messages/pt-PT/storySteps.json
@@ -127,6 +127,11 @@
         "title": "✨ A Criar a Tua História",
         "message": "Os nossos Oompa Loompas estão a trabalhar arduamente para preparar a tua história! Isto pode demorar um momento...",
         "pleaseWait": "Por favor aguarda enquanto fazemos a nossa magia! ✨"
+      },
+      "errors": {
+        "failedGetUser": "Falha ao obter informa\u00e7\u00e3o do utilizador.",
+        "failedCreate": "Falha ao criar hist\u00f3ria.",
+        "unknown": "Ocorreu um erro desconhecido."
       }
     },
     "step3": {


### PR DESCRIPTION
## Summary
- extract step2 error messages to i18n
- add translation keys in EN and PT locale files
- use translated strings in step 2 page

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_688cccddc770832896a18f47da8c18ae