### PR TITLE
Use translation keys for step 5 errors

### DIFF
--- a/src/app/[locale]/tell-your-story/step-5/page.tsx
+++ b/src/app/[locale]/tell-your-story/step-5/page.tsx
@@ -81,7 +81,7 @@ function Step5Page() {
       setStoryData(data.story);
     } catch (error) {
       console.error('Error fetching story data:', error);
-      setError(t('alerts.failedToFetchData'));
+      setError(t('alerts.failedToFetchStoryData'));
     }
   };
   const fetchUserCredits = async () => {
@@ -94,7 +94,7 @@ function Step5Page() {
       setUserCredits(data.currentBalance || 0);
     } catch (error) {
       console.error('Error fetching user credits:', error);
-      setError(t('alerts.failedToLoadCreditInformation'));
+      setError(t('alerts.failedToFetchUserCredits'));
     }
   };
 
@@ -110,7 +110,7 @@ function Step5Page() {
       }
     } catch (error) {
       console.error('Error fetching pricing data:', error);
-      setError(t('alerts.failedToLoadPricingInformation'));
+      setError(t('alerts.failedToFetchPricingData'));
     }
   };
   
@@ -149,7 +149,9 @@ function Step5Page() {
 
       if (!creditsResponse.ok) {
         const creditsError = await creditsResponse.json();
-        throw new Error(creditsError.error || 'Failed to deduct credits');
+        console.error('Failed to deduct credits:', creditsError);
+        setError(t('alerts.failedToDeductCredits'));
+        return;
       }
 
       const creditsResult = await creditsResponse.json();
@@ -178,7 +180,9 @@ function Step5Page() {
 
       if (!response.ok) {
         const errorData = await response.json();
-        throw new Error(errorData.error || 'Failed to complete story');
+        console.error('Failed to complete story:', errorData);
+        setError(t('alerts.failedToCompleteStory'));
+        return;
       }
 
       const result = await response.json();
@@ -200,7 +204,7 @@ function Step5Page() {
       setStoryGenerationStarted(true);
     } catch (error) {
       console.error('Error completing story:', error);
-      setError(error instanceof Error ? error.message : t('alerts.failedToCompleteStory'));
+      setError(t('alerts.failedToCompleteStory'));
     } finally {
       setSubmitting(false);
     }

--- a/src/messages/en-US/storySteps.json
+++ b/src/messages/en-US/storySteps.json
@@ -275,7 +275,9 @@
       "storyDataNotAvailable": "Story data not available. Please try again.",
       "stepProgress": "Step {currentStep} of {totalSteps}",
       "alerts": {
-        "failedToFetchData": "Failed to fetch story data. Please try again.",
+        "failedToFetchStoryData": "Failed to fetch story data. Please try again.",
+        "failedToFetchUserCredits": "Failed to fetch user credits. Please try again.",
+        "failedToFetchPricingData": "Failed to fetch pricing data. Please try again.",
         "failedToDeductCredits": "Failed to deduct credits. Please try again.",
         "dataFetchError": "Error fetching data. Please check your connection and try again.",
         "failedToLoadCreditInformation": "Failed to load credit information. Please try again.",

--- a/src/messages/pt-PT/storySteps.json
+++ b/src/messages/pt-PT/storySteps.json
@@ -275,7 +275,9 @@
       "storyDataNotAvailable": "Dados da história não disponíveis. Tenta novamente.",
       "stepProgress": "Passo {currentStep} de {totalSteps}",
       "alerts": {
-        "failedToFetchData": "Falha ao obter dados da história. Por favor tente novamente.",
+        "failedToFetchStoryData": "Falha ao obter dados da história. Por favor tente novamente.",
+        "failedToFetchUserCredits": "Falha ao obter créditos do utilizador. Por favor tente novamente.",
+        "failedToFetchPricingData": "Falha ao obter dados de preços. Por favor tente novamente.",
         "failedToDeductCredits": "Falha ao deduzir créditos. Por favor tente novamente.",
         "dataFetchError": "Erro ao obter dados. Por favor verifique a sua ligação e tente novamente.",
         "failedToLoadCreditInformation": "Falha ao carregar informação de créditos. Por favor tente novamente.",


### PR DESCRIPTION
## Summary
- add explicit message keys for step 5 alerts
- use those translation keys in the step 5 page error handlers

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ccce1a65483288514ef28890a93b1