### PR TITLE
Add basic Spanish locale files

### DIFF
--- a/src/messages/es-ES/common.json
+++ b/src/messages/es-ES/common.json
@@ -1,0 +1,27 @@
+{
+  "common": {
+    "Header": {
+      "navigation": {
+        "homepage": "Inicio",
+        "getInspired": "Inspírate",
+        "tellYourStory": "Cuenta Tu Historia",
+        "myStories": "Mis Historias",
+        "pricing": "Precios",
+        "dashboard": "Panel"
+      },
+      "auth": {
+        "signIn": "Iniciar Sesión",
+        "signUp": "Registrarse"
+      },
+      "logoAlt": "Logo de Mythoria"
+    },
+    "Footer": {
+      "aboutFounder": "Me llamo Rodrigo, acabo de cumplir 18 años y me encanta escuchar historias desde pequeño.",
+      "readMyStory": "Lee mi propia historia",
+      "privacyPolicy": "Privacidad y Cookies",
+      "termsConditions": "Términos y Condiciones",
+      "contactUs": "Contacto",
+      "copyright": "Aventuras Contemporâneas, Lda"
+    }
+  }
+}

--- a/src/messages/es-ES/metadata.json
+++ b/src/messages/es-ES/metadata.json
@@ -1,0 +1,33 @@
+{
+  "title": "Mythoria | Creador de Libros Personalizados",
+  "description": "Crea libros únicos y totalmente ilustrados con la IA generativa de Mythoria. Convierte cualquier historia en un e-book, audiolibro o regalo impreso en minutos.",
+  "defaultTitle": "Mythoria",
+  "defaultDescription": "Creador de Libros Personalizados",
+  "brand": {
+    "name": "Mythoria",
+    "tagline": "Creador de Libros Personalizados"
+  },
+  "openGraph": {
+    "title": "Mythoria | Creador de Libros Personalizados",
+    "description": "Convierte tus ideas en libros personalizados y bellamente ilustrados — léelos, escúchalos o imprímelos.",
+    "image": "https://mythoria.pt/assets/og/mythoria_en.jpg",
+    "url": "https://mythoria.pt/es-ES/"
+  },
+  "structuredData": {
+    "name": "Mythoria",
+    "description": "Mythoria permite a cualquiera crear y personalizar libros totalmente ilustrados usando IA generativa.",
+    "inLanguage": "es-ES"
+  },
+  "manifest": {
+    "name": "Mythoria - Creador de Libros Personalizados",
+    "short_name": "Mythoria",
+    "description": "Crea libros únicos y totalmente ilustrados",
+    "shortcuts": {
+      "createStory": {
+        "name": "Crear Historia",
+        "short_name": "Crear",
+        "description": "Empieza a crear una nueva historia"
+      }
+    }
+  }
+}

--- a/src/messages/es-ES/publicPages.json
+++ b/src/messages/es-ES/publicPages.json
@@ -1,0 +1,102 @@
+{
+  "HomePage": {
+    "title": "Bienvenido",
+    "hero": {
+      "writeYourOwn": "Escribe tu propia",
+      "subtitle": "Convierte a cualquiera en el héroe de un libro bellamente ilustrado — para niños, adultos o equipos completos.",
+      "subtitleEmphasized": "a cualquiera",
+      "tryItNow": "Pruébalo ahora"
+    },
+    "words": [
+      "Historia",
+      "Aventura",
+      "Recuerdo",
+      "Crónica",
+      "Ficción",
+      "Fábula",
+      "Odisea",
+      "Prosa",
+      "Libro",
+      "Novela",
+      "Romance",
+      "Manuscrito",
+      "Relato",
+      "Mito"
+    ],
+    "fallbackWords": [
+      "Aventura",
+      "Historia de Amor",
+      "Misterio",
+      "Cuento de Hadas"
+    ],
+    "altTexts": {
+      "kidsBook": "Libro Infantil",
+      "groupsYearbooks": "Grupos y Anuarios",
+      "adultBook": "Cómo conocí a vuestra madre",
+      "companyBook": "Libro de Empresa"
+    },
+    "comingSoon": {
+      "title": "Nuestra historia acaba de comenzar...",
+      "subtitle": "Mythoria está preparando algo mágico. Trabajamos duro, junto con la IA, para traerte un nuevo mundo de historias personalizadas. ¡Permanece atento, la aventura estará disponible pronto! 🧙‍♂️📚✨"
+    },
+    "audiences": {
+      "kids": {
+        "title": "Niños",
+        "description": "¡Convierte a tu hijo, nieto, sobrino o sobrina en el héroe de su propia aventura mágica!"
+      },
+      "groups": {
+        "title": "Grupos y Anuarios",
+        "description": "¡Inmortaliza el espíritu de tu equipo y los recuerdos de tu grupo!"
+      },
+      "adults": {
+        "title": "Adultos",
+        "description": "Revive tu historia de amor o un viaje irrepetible como un magnífico recuerdo ilustrado."
+      },
+      "companies": {
+        "title": "Empresas",
+        "description": "Regala a clientes o familias de empleados un libro personalizado con tu marca que mantenga tu logo en la estantería."
+      }
+    },
+    "howItWorks": {
+      "title": "Con Mythoria, crear tu propia historia es fácil:",
+      "steps": {
+        "step1": {
+          "title": "El Autor",
+          "description": "Inicia sesión y cuéntale a Mythoria quién eres. Serás el orgulloso autor y propietario de tu historia única."
+        },
+        "step2": {
+          "title": "La Historia",
+          "description": "Comparte fácilmente tu idea escribiendo, hablando o incluso dibujando. Mythoria transforma tu concepto en magia."
+        },
+        "step3": {
+          "title": "Los Personajes",
+          "description": "Mythoria identifica a los personajes, pero puedes personalizar cada detalle. Describe su aspecto, pasiones y rasgos únicos."
+        },
+        "step4": {
+          "title": "La Trama",
+          "description": "Moldea tu historia como quieras: elige el estilo gráfico, el tono, tu público y ajusta todos los detalles."
+        },
+        "step5": {
+          "title": "El Regalo",
+          "description": "Elige cómo quieres recibir tu obra maestra: como eBook, audiolibro o un libro impreso precioso."
+        },
+        "step6": {
+          "title": "Vive la Magia",
+          "description": "Los niños se emocionarán al verse en aventuras trepidantes y los adultos disfrutarán reviviendo recuerdos entrañables."
+        }
+      },
+      "stepLabels": {
+        "step1": "Paso 1",
+        "step2": "Paso 2",
+        "step3": "Paso 3",
+        "step4": "Paso 4",
+        "step5": "Paso 5",
+        "step6": "Paso 6"
+      },
+      "conclusion": "¡Nuestros Oompa‑Loompas de la Fábrica de Historias se encargan del resto y dan vida a tu historia!"
+    },
+    "community": {
+      "title": "¡Únete a Nuestra Creciente Comunidad de Narradores!"
+    }
+  }
+}

--- a/src/messages/es-ES/termsAndConditions.html
+++ b/src/messages/es-ES/termsAndConditions.html
@@ -1,0 +1,100 @@
+<Artículo>
+
+<h1> Términos y condiciones </h1>
+<p>These Terms & Conditions (“<strong>T&C</strong>”) form a binding contract between you (“<strong>user</strong>”, “you”) and <strong>Aventuras Contemporâneas, Lda.</strong>, Rua Cais do Lugan, N.º 224, 2.º Direito, 4400‑492 Vila Nova de Gaia, Portugal ("<strong> mythoria </strong>", "nosotros", "nosotros"). Creando una cuenta o utilizando el servicio, acepta estar sujeto a estos T&C. <br>
+Contacto: <a href = "mailto: legal@mythoria.pt"> legal@mythoria.pt </a>. </p>
+
+<Sección ID = "Definiciones">
+<h2> 1. Definiciones </h2>
+<ul>
+  <li> <strong> Servicio </strong> - La plataforma web/móvil que permite a los usuarios crear libros electrónicos, audio y libros impresos generados por IA. </li>.
+  <li> <strong> contenido </strong> - cualquier texto, imagen, audio, indicador u otro material cargado o generado por el servicio. </li>
+  <li> <strong> créditos </strong> - Unidades pre -pagadas canjeables para tareas de generación. </li>
+</ul>
+</section>
+
+<sección id = "aceptación">
+<H2> 2. Aceptación y alcance </h2>
+<p> (a) Usted acepta estos T&C marcando "Estoy de acuerdo con los Términos y Condiciones y la Política de privacidad" en Sign -Up y nuevamente cada vez que presiona <em> Generar </em>. </p>.
+<p> (b) Estos T&C se aplican a todo el uso del servicio dentro del EEE y, donde se aplica la Sección 15, los Estados Unidos. </p>
+</section>
+
+<sección id = "elegibilidad">
+<H2> 3. Elegibilidad y cuentas </h2>
+<p> (a) Debe tener 18 años, o 13-17 con consentimiento de los padres verificado, para abrir una cuenta. Los niños menores de 13 años pueden participar solo a través de una cuenta administrada por los padres. </p>
+<p> (b) Usted es responsable de salvaguardar sus credenciales. La mitoria no es responsable del uso no autorizado que resulte de su fracaso para protegerlos. </p>
+</section>
+
+<Sección ID = "Servicio">
+<H2> 4. Descripción del servicio y actualizaciones </h2>
+<p> El servicio le permite ingresar un aviso o dictado y, via, Google Vertex AI y Operai Models, genera un libro electrónico, un libro de audio opcional y (donde está disponible) una copia impresa. La salida se etiqueta automáticamente "Generado por AI". </p>
+<p> Mantendremos el servicio de conformidad con el contrato y proporcionaremos actualizaciones de seguridad o funcionalidad necesarias según lo requiera la Directiva (UE) 2019/770. </p>
+</section>
+
+<Sección ID = "IP">
+<H2> 5. Derechos intelectuales de propiedad </h2>
+<p> (a) <strong> su propiedad. </strong> En cuanto a usted y Mythoria, usted posee todos los derechos en la producción generada por AI. </p>
+<p> (b) <strong> Licencia a Mythoria. </strong> le otorga a Mythoria una licencia mundial, no exclusiva, libre de regalías para almacenar, procesar y mostrar su contenido únicamente para operar el servicio y, si opta expresamente, para mostrar su libro terminado. </p>
+<p> (c) <strong> garantías e indemnización. </strong> garantiza que sus aportes no infringen los derechos de terceros o la ley aplicable e indemnizará la mitoria contra las reclamaciones relacionadas. </p>.
+</section>
+
+<sección id = "pagos">
+<H2> 6. Créditos, precios y reembolsos </h2>
+<p> (a) Los precios se muestran en euros e incluyen la tasa de IVA portuguesa reducida del 6 % aplicable a los libros electrónicos. </p>
+<p> (b) Tiene 14 días para retirarse de una compra de crédito bajo Decreto - Lei N.º 24/2014, pero solicita expresamente un rendimiento inmediato y reconoce que el derecho se pierde una vez que comienza la generación. </p>
+<p> (c) Las generaciones fallidas acreditan automáticamente su cuenta; Los reembolsos monetarios se aplican solo cuando se pruebe la no conformidad bajo la Directiva 2019/770. </p>
+<p> (d) Mythoria emite e -Invoices que cumplen con las reglas de Portugal (facturas en PDF tratadas como electrónicas hasta el 31 de diciembre de 2024). </p>
+</section>
+
+<Sección id = "Content-Policy">
+<H2> 7. Política y moderación de contenido </h2>
+<p> (a) Prohibido: contenido ilegal, difamatorio o sexual que involucra menores. </p>
+<p> (b) Aviso y acción: Mythoria proporciona un formulario en línea y abuso@ dirección; Los avisos válidos de contenido ilegal se revisan dentro de las 24 h en línea con DSA Art16. </p>
+<p> (c) Los infractores repetidos pueden tener cuentas suspendidas después de tres derribos válidos dentro de los 12 meses. </p>
+</section>
+
+<sección id = "ai">
+<H2> 8. Divulgaciones específicas de AI </h2>
+<p> (a) Las salidas están generadas por máquina; pueden ocurrir errores objetivos; Ningún resultado constituye asesoramiento profesional. </p>
+<p> (b) Mythoria publica o enlaces a resúmenes suministrados por el proveedor de los datos de capacitación con derechos de autor anualmente, cumpliendo las tareas de transparencia de la Ley AI. </p>
+</section>
+
+<sección id = "privacidad">
+<H2> 9. Protección de datos </h2>
+<p> (a) El procesamiento de datos personales se explica en el aviso de privacidad separado. </p>
+<p> (b) Cuentas de los niños predeterminadas a la configuración de alta privacidad en línea con el código de diseño apropiado para la edad de ICO. </p>
+<p> (c) Las imágenes de origen/voz se conservan durante dos años, luego se eliminan automáticamente. </p>
+</section>
+
+<Sección ID = "Garantía">
+<H2> 10. Garantía, nivel de servicio y responsabilidad </h2>
+<p> (a) Mythoria se dirige al 99% de tiempo de actividad mensual, pero no ofrece SLA para las características beta. </p>
+<p> (b) No somos responsables de las fallas causadas por eventos más allá de nuestro control razonable, incluidas las interrupciones aguas arriba. </p>
+<p> (c) Excepto por la intención, la negligencia grave, la muerte o la lesión personal, la responsabilidad agregada de Mythoria se limita a tres (3) veces las tarifas que pagó en los 12 meses anteriores. </p>
+</section>
+
+<sección id = "imprimir">
+<H2> 11. Libros impresos </h2>
+<p> Los defectos en copias impresas cumplidas a través de nuestro socio impreso serán remediados por una copia de reemplazo gratuita enviada al costo de Mythoria. </p>
+</section>
+
+<sección id = "cambia">
+<H2> 12. Cambios a estos T&C </h2>
+<p> Los cambios en el material serán notificados por E -Cail con 30 días de anticipación. Si se opone, puede cancelar créditos no utilizados para un reembolso pro -Rata. </p>
+</section>
+
+<Sección ID = "Ley">
+<H2> 13. Registro de derecho y resolución de disputas </h2>
+<p> (a) Estos T&C se rigen por la ley portuguesa, los tribunales de Vila Nova de Gaia con jurisdicción exclusiva. </p>
+<p> (b) Los consumidores también pueden usar la plataforma de resolución de disputas en línea de la UE (<a href = "https://ec.europa.eu/consumers/odr"> ec.europa.eu/consumers/odr </a>) mientras sigue operativo. </p>
+</section>
+
+<Sección ID = "Contacto">
+<H2> 14. Detalles de contacto </h2>
+<p> <strong> aventuras contemporâNeas, lda. </strong> <br>
+Rua Cais do Lugan, N.º 224, 2.º Direito <br>
+4400‑492 Vila Nova de Gaia, Portugal <br>
+Correo electrónico: <a href = "mailto: legal@mythoria.pt"> legal@mythoria.pt </a> </p>
+</section>
+
+</artículo>


### PR DESCRIPTION
## Summary
- add `es-ES` directory with basic translations
- translate metadata and terms & conditions to Spanish
- provide Spanish homepage strings and common header/footer text

## Testing
- `node scripts/verify-translations.js`

------
https://chatgpt.com/codex/tasks/task_e_688ce6385d308328b4e202dc73212ca2