### PR TITLE
Add es-ES locale support

### DIFF
--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -3,7 +3,7 @@ import {createNavigation} from 'next-intl/navigation';
  
 export const routing = defineRouting({
   // A list of all locales that are supported
-  locales: ['en-US', 'pt-PT'],
+  locales: ['en-US', 'pt-PT', 'es-ES'],
  
   // Used when no locale matches
   defaultLocale: 'en-US'


### PR DESCRIPTION
## Summary
- enable Spanish locale in routing

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run dev` *(fails to serve pages in this environment)*
- `curl http://localhost:3000/api/manifest?locale=es-ES`

------
https://chatgpt.com/codex/tasks/task_e_688cfc89199c8328925e62cb91cbe1dc