### PR TITLE
chore(i18n): isolate MyStoriesPage translations

### DIFF
--- a/src/app/[locale]/buy-credits/page.tsx
+++ b/src/app/[locale]/buy-credits/page.tsx
@@ -43,7 +43,7 @@ function BuyCreditsContent() {
 		const searchParams = useSearchParams();
 	   const t = useTranslations('BuyCreditsPage');
 	   const tPricing = useTranslations('PricingPage');
-	   const tMyStories = useTranslations('MyStoriesPage');
+	   const tMyStoriesPage = useTranslations('MyStoriesPage');
 	   const tRevolut = useTranslations('RevolutPayment');
 	   const locale = useLocale();
 	   const [cart, setCart] = useState<CartItem[]>([]);
@@ -507,14 +507,14 @@ function BuyCreditsContent() {
 							<div className="text-center space-y-6">
 								<h1 className="text-4xl font-bold">{t('header.title')}</h1>
 								<p className="text-lg text-gray-600 max-w-2xl mx-auto">
-									{tMyStories('signedOut.needSignIn')}
+									{tMyStoriesPage('signedOut.needSignIn')}
 								</p>
 								<div className="flex flex-col sm:flex-row gap-4 justify-center">
 									<Link href={`/${locale}/sign-in`} className="btn btn-primary">
-										{tMyStories('signedOut.signIn')}
+										{tMyStoriesPage('signedOut.signIn')}
 									</Link>
 									<Link href={`/${locale}/sign-up`} className="btn btn-outline">
-										{tMyStories('signedOut.createAccount')}
+										{tMyStoriesPage('signedOut.createAccount')}
 									</Link>
 								</div>
 							</div>

--- a/src/messages/en-US/publicPages.json
+++ b/src/messages/en-US/publicPages.json
@@ -33,49 +33,6 @@
       "subtitle": "Start your storytelling journey today"
     }
   },
-  "MyStoriesPage": {
-    "title": "Hello",
-    "writeNewStory": "New Story",
-    "signedOut": {
-      "welcome": "Welcome",
-      "needSignIn": "Every storyteller needs an account to keep their magical credits safe!",
-      "signIn": "Sign In",
-      "createAccount": "Create Account"
-    },
-    "tabs": {
-      "myStories": "My Stories",
-      "myCharacters": "My Characters"
-    },
-    "noStories": {
-      "title": "Your collection of stories is waiting to begin! 📚✨",
-      "subtitle": "Every great storyteller started with a single tale. Ready to write your first magical adventure?",
-      "action": "Start Your First Story"
-    },
-    "table": {
-      "date": "Date",
-      "title": "Title",
-      "status": "Status",
-      "actions": "Actions"
-    },
-    "status": {
-      "draft": "Draft",
-      "writing": "Writing",
-      "published": "Published"
-    },
-    "actions": {
-      "share": "Share",
-      "edit": "Edit",
-      "delete": "Delete",
-      "print": "Order Print",
-      "printNotAvailable": "Print not available for this story"
-    },
-    "deleteConfirm": {
-      "title": "Delete Story",
-      "message": "Are you sure you want to delete this story? This action cannot be undone.",
-      "cancel": "Cancel",
-      "confirm": "Delete"
-    }
-  },
   "MyCharactersPage": {
     "noCharacters": {
       "title": "You don't have any characters yet!",

--- a/src/messages/es-ES/publicPages.json
+++ b/src/messages/es-ES/publicPages.json
@@ -33,49 +33,6 @@
       "subtitle": "Empieza hoy mismo tu viaje de narrador"
     }
   },
-  "MyStoriesPage": {
-    "title": "Hola",
-    "writeNewStory": "Nueva historia",
-    "signedOut": {
-      "welcome": "¡Bienvenido!",
-      "needSignIn": "Todo narrador necesita una cuenta para mantener sus créditos mágicos a buen recaudo.",
-      "signIn": "Iniciar sesión",
-      "createAccount": "Crear cuenta"
-    },
-    "tabs": {
-      "myStories": "Mis historias",
-      "myCharacters": "Mis personajes"
-    },
-    "noStories": {
-      "title": "¡Tu colección de historias está esperando a comenzar! 📚✨",
-      "subtitle": "Todo gran narrador empezó con un solo relato. ¿Listo para escribir tu primera aventura mágica?",
-      "action": "Empieza tu primera historia"
-    },
-    "table": {
-      "date": "Fecha",
-      "title": "Título",
-      "status": "Estado",
-      "actions": "Acciones"
-    },
-    "status": {
-      "draft": "Borrador",
-      "writing": "En proceso",
-      "published": "Publicado"
-    },
-    "actions": {
-      "share": "Compartir",
-      "edit": "Editar",
-      "delete": "Eliminar",
-      "print": "Pedir impresión",
-      "printNotAvailable": "La impresión no está disponible para esta historia"
-    },
-    "deleteConfirm": {
-      "title": "Eliminar historia",
-      "message": "¿Seguro que quieres eliminar esta historia? Esta acción no se puede deshacer.",
-      "cancel": "Cancelar",
-      "confirm": "Eliminar"
-    }
-  },
   "MyCharactersPage": {
     "noCharacters": {
       "title": "¡Aún no tienes personajes!",

--- a/src/messages/pt-PT/publicPages.json
+++ b/src/messages/pt-PT/publicPages.json
@@ -33,49 +33,6 @@
       "subtitle": "Comece hoje a sua jornada de narrativa"
     }
   },
-  "MyStoriesPage": {
-    "title": "Olá",
-    "writeNewStory": "História",
-    "signedOut": {
-      "welcome": "Bem-vindo",
-      "needSignIn": "Todo contador precisa de uma conta para guardar os seus créditos mágicos!",
-      "signIn": "Entrar",
-      "createAccount": "Criar Conta"
-    },
-    "tabs": {
-      "myStories": "Histórias",
-      "myCharacters": "Personagens"
-    },
-    "noStories": {
-      "title": "A sua coleção de histórias está à espera de começar! 📚✨",
-      "subtitle": "Todos os grandes contadores de histórias começaram com uma única narrativa. Pronto para escrever a sua primeira aventura mágica?",
-      "action": "Comece a Sua Primeira História"
-    },
-    "table": {
-      "date": "Data",
-      "title": "Título",
-      "status": "Estado",
-      "actions": "Ações"
-    },
-    "status": {
-      "draft": "Rascunho",
-      "writing": "A Escrever",
-      "published": "Publicado"
-    },
-    "actions": {
-      "share": "Partilhar",
-      "edit": "Editar",
-      "delete": "Eliminar",
-      "print": "Encomendar Impressão",
-      "printNotAvailable": "Impressão não disponível para esta história"
-    },
-    "deleteConfirm": {
-      "title": "Eliminar História",
-      "message": "Tem a certeza de que quer eliminar esta história? Esta ação não pode ser desfeita.",
-      "cancel": "Cancelar",
-      "confirm": "Eliminar"
-    }
-  },
   "MyCharactersPage": {
     "noCharacters": {
       "title": "Ainda não tem personagens!",


### PR DESCRIPTION
## Summary
- remove MyStoriesPage keys from publicPages and rely on dedicated file
- rename MyStoriesPage translation hook to `tMyStoriesPage`
- ensure MyStoriesPage namespace is loaded in i18n request config

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_689d2d61b9ac8328b2851a1d09e6fa83