### PR TITLE
refactor public story listen translations

### DIFF
--- a/src/app/[locale]/p/[slug]/listen/page.tsx
+++ b/src/app/[locale]/p/[slug]/listen/page.tsx
@@ -47,7 +47,7 @@ export default function PublicListenPage() {
   const params = useParams();
   const router = useRouter();
   const locale = useLocale();
-  const t = useTranslations('PublicStoryPage');
+  const tPublicStoryPage = useTranslations('PublicStoryPage');
   const tCommon = useTranslations('common');
   const slug = Array.isArray(params?.slug)
     ? (params?.slug[0] ?? '')
@@ -86,18 +86,18 @@ export default function PublicListenPage() {
           
           // Check if story has audio
           if (!result.story.hasAudio) {
-            setError(t('listen.audioNotAvailable'));
+            setError(tPublicStoryPage('listen.audioNotAvailable'));
           }
           
           console.log('[Public Listen Page] Story loaded successfully');
         } else {
           console.error('[Public Listen Page] API returned error:', result.error);
-          setError(result.error || t('errors.notFound'));
+          setError(result.error || tPublicStoryPage('errors.notFound'));
         }
       } catch (err) {
         console.error('[Public Listen Page] Error fetching public story:', err);
         const errorMessage = err instanceof Error ? err.message : 'Unknown error';
-        setError(`${t('errors.failedToLoadStory')}: ${errorMessage}`);
+        setError(`${tPublicStoryPage('errors.failedToLoadStory')}: ${errorMessage}`);
       } finally {
         setLoading(false);
       }
@@ -111,9 +111,9 @@ export default function PublicListenPage() {
   useEffect(() => {
     if (data?.story) {
       const story = data.story;
-      document.title = t('metadata.listenPageTitle', { title: story.title });
+      document.title = tPublicStoryPage('metadata.listenPageTitle', { title: story.title });
     }
-  }, [data, t]);
+  }, [data, tPublicStoryPage]);
 
   const navigateBackToStory = () => {
     router.push(`/${locale}/p/${slug}`);
@@ -124,8 +124,8 @@ export default function PublicListenPage() {
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center space-y-4">
           <FiLoader className="animate-spin text-4xl text-primary mx-auto" />
-          <h2 className="text-xl font-semibold">{t('loading.title')}</h2>
-          <p className="text-gray-600">{t('loading.subtitle')}</p>
+          <h2 className="text-xl font-semibold">{tPublicStoryPage('loading.title')}</h2>
+          <p className="text-gray-600">{tPublicStoryPage('loading.subtitle')}</p>
         </div>
       </div>
     );
@@ -136,8 +136,8 @@ export default function PublicListenPage() {
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center space-y-4 max-w-md mx-auto px-4">
           <FiAlertCircle className="text-4xl text-red-500 mx-auto" />
-          <h2 className="text-xl font-semibold text-gray-900">{t('errors.notFound')}</h2>
-          <p className="text-gray-600">{error || t('errors.notFoundDesc')}</p>
+          <h2 className="text-xl font-semibold text-gray-900">{tPublicStoryPage('errors.notFound')}</h2>
+          <p className="text-gray-600">{error || tPublicStoryPage('errors.notFoundDesc')}</p>
           
           <div className="space-y-2">
             <button
@@ -167,12 +167,12 @@ export default function PublicListenPage() {
               >
                 <FiArrowLeft className="w-4 h-4 mr-2" />
                 <span className="hidden sm:inline">{tCommon('Actions.backToStory')}</span>
-                <span className="sm:hidden">{t('listen.backMobile')}</span>
+                <span className="sm:hidden">{tPublicStoryPage('listen.backMobile')}</span>
               </button>
               
               <h1 className="text-xl font-semibold text-gray-900 text-center flex-1 mx-4">
                 <FiVolume2 className="w-5 h-5 inline mr-2" />
-                {t('listen.title', { title: story.title })}
+                {tPublicStoryPage('listen.title', { title: story.title })}
               </h1>
               
               <div className="w-20"></div> {/* Spacer for centering */}
@@ -189,22 +189,22 @@ export default function PublicListenPage() {
               chapters={getAudioChapters(
                 data.story.audiobookUri, 
                 data.chapters, 
-                (number) => t('listen.chapterFallback', { number })
+                (number) => tPublicStoryPage('listen.chapterFallback', { number })
               )}
               {...audioPlayer}
             />
           ) : (
             <div className="bg-white rounded-lg shadow-sm border p-8 text-center">
               <FiAlertCircle className="text-4xl text-gray-400 mx-auto mb-4" />
-              <h3 className="text-lg font-medium text-gray-900 mb-2">{t('listen.audioNotAvailableTitle')}</h3>
+              <h3 className="text-lg font-medium text-gray-900 mb-2">{tPublicStoryPage('listen.audioNotAvailableTitle')}</h3>
               <p className="text-gray-600">
-                {t('listen.audioNotAvailableDesc')}
+                {tPublicStoryPage('listen.audioNotAvailableDesc')}
               </p>
               <button
                 onClick={navigateBackToStory}
                 className="btn btn-primary mt-4"
               >
-                {t('listen.backToStory')}
+                {tPublicStoryPage('listen.backToStory')}
               </button>
             </div>
           )}

--- a/src/app/[locale]/p/[slug]/page.tsx
+++ b/src/app/[locale]/p/[slug]/page.tsx
@@ -55,7 +55,7 @@ interface PublicStoryData {
 export default function PublicStoryPage() {
   const params = useParams();
   const locale = useLocale();
-  const t = useTranslations('PublicStoryPage');
+  const tPublicStoryPage = useTranslations('PublicStoryPage');
   const tCommon = useTranslations('common');
   const tGet = useTranslations('GetInspiredPage');
   const slug = Array.isArray(params?.slug)
@@ -85,19 +85,19 @@ export default function PublicStoryPage() {
           
         } else {
           console.error('[Public Page] API returned error:', result.error);
-          setError(result.error || t('errors.notFound'));
+          setError(result.error || tPublicStoryPage('errors.notFound'));
         }
       } catch (err) {
         console.error('[Public Page] Error fetching public story:', err);
         const errorMessage = err instanceof Error ? err.message : 'Unknown error';
-        setError(`${t('errors.failedToLoadStory')}: ${errorMessage}`);
+        setError(`${tPublicStoryPage('errors.failedToLoadStory')}: ${errorMessage}`);
       } finally {
         setLoading(false);
       }
     };
 
     fetchPublicStory();
-  }, [slug, t]);
+  }, [slug, tPublicStoryPage]);
   // Generate metadata for the page
   useEffect(() => {
     if (data?.story) {
@@ -107,7 +107,8 @@ export default function PublicStoryPage() {
       
       // Set meta description
       const metaDescription = document.querySelector('meta[name="description"]');
-      const description = story.synopsis || story.plotDescription || t('metadata.defaultDescription', { title: story.title });
+      const description =
+        story.synopsis || story.plotDescription || tPublicStoryPage('metadata.defaultDescription', { title: story.title });
       if (metaDescription) {
         metaDescription.setAttribute('content', description);
       } else {
@@ -137,7 +138,7 @@ export default function PublicStoryPage() {
       setMetaTag('og:image', `${baseUrl}/api/og/story/${slug}`);
       setMetaTag('og:image:width', '1200');
       setMetaTag('og:image:height', '630');
-      setMetaTag('og:image:alt', t('metadata.coverImageAlt', { title: story.title }));
+      setMetaTag('og:image:alt', tPublicStoryPage('metadata.coverImageAlt', { title: story.title }));
 
       // Twitter Card tags
       const setTwitterTag = (name: string, content: string) => {
@@ -161,8 +162,8 @@ export default function PublicStoryPage() {
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center space-y-4">
           <FiLoader className="animate-spin text-4xl text-primary mx-auto" />
-          <h2 className="text-xl font-semibold">{t('loading.title')}</h2>
-          <p className="text-gray-600">{t('loading.subtitle')}</p>
+          <h2 className="text-xl font-semibold">{tPublicStoryPage('loading.title')}</h2>
+          <p className="text-gray-600">{tPublicStoryPage('loading.subtitle')}</p>
         </div>
       </div>
     );
@@ -172,8 +173,8 @@ export default function PublicStoryPage() {
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center space-y-4 max-w-md mx-auto px-4">
           <FiAlertCircle className="text-4xl text-red-500 mx-auto" />
-          <h2 className="text-xl font-semibold text-gray-900">{t('errors.notFound')}</h2>
-          <p className="text-gray-600">{error || t('errors.notFoundDesc')}</p>
+          <h2 className="text-xl font-semibold text-gray-900">{tPublicStoryPage('errors.notFound')}</h2>
+          <p className="text-gray-600">{error || tPublicStoryPage('errors.notFoundDesc')}</p>
           
           <div className="space-y-2">
             <a
@@ -209,8 +210,8 @@ export default function PublicStoryPage() {
                     className="btn btn-primary btn-sm flex items-center gap-2 text-xs sm:text-sm"
                   >
                     <FiPrinter className="w-3 h-3 sm:w-4 sm:h-4" />
-                    <span className="hidden min-[480px]:inline">{t('actions.orderPrint')}</span>
-                    <span className="min-[480px]:hidden">{t('actions.print')}</span>
+                    <span className="hidden min-[480px]:inline">{tPublicStoryPage('actions.orderPrint')}</span>
+                    <span className="min-[480px]:hidden">{tPublicStoryPage('actions.print')}</span>
                   </a>
                   {story.hasAudio && (
                     <a
@@ -218,8 +219,8 @@ export default function PublicStoryPage() {
                       className="btn btn-secondary btn-sm flex items-center gap-2 text-xs sm:text-sm"
                     >
                       <FiVolume2 className="w-3 h-3 sm:w-4 sm:h-4" />
-                      <span className="hidden min-[480px]:inline">{t('actions.listen')}</span>
-                      <span className="min-[480px]:hidden">{t('actions.listenMobile')}</span>
+                      <span className="hidden min-[480px]:inline">{tPublicStoryPage('actions.listen')}</span>
+                      <span className="min-[480px]:hidden">{tPublicStoryPage('actions.listenMobile')}</span>
                     </a>
                   )}
                 </div>
@@ -229,7 +230,7 @@ export default function PublicStoryPage() {
             <div className="flex flex-wrap items-center gap-4 text-sm text-gray-600 mt-4">
               <div className="flex items-center gap-1">
                 <FiUser />
-                <span>{t('labels.by')} {story.authorName || t('labels.unknownAuthor')}</span>
+                <span>{tPublicStoryPage('labels.by')} {story.authorName || tPublicStoryPage('labels.unknownAuthor')}</span>
               </div>
                 <div className="flex items-center gap-1">
                 <FiCalendar />
@@ -259,7 +260,7 @@ export default function PublicStoryPage() {
             
             {(story.synopsis || story.plotDescription) && (
               <div className="mt-4 p-4 bg-gray-50 rounded-lg">
-                <h3 className="font-bold text-gray-900 mb-2">{t('labels.synopsis')}</h3>
+                <h3 className="font-bold text-gray-900 mb-2">{tPublicStoryPage('labels.synopsis')}</h3>
                 <p className="text-gray-700 leading-relaxed text-sm">
                   {story.synopsis || story.plotDescription}
                 </p>
@@ -292,9 +293,9 @@ export default function PublicStoryPage() {
             <div className="max-w-4xl mx-auto">
               <div className="bg-white rounded-lg shadow-sm border p-8 text-center">
                 <FiAlertCircle className="text-4xl text-gray-400 mx-auto mb-4" />
-                <h3 className="text-lg font-medium text-gray-900 mb-2">{t('errors.contentNotAvailable')}</h3>
+                <h3 className="text-lg font-medium text-gray-900 mb-2">{tPublicStoryPage('errors.contentNotAvailable')}</h3>
                 <p className="text-gray-600">
-                  {t('errors.contentNotAvailableDesc')}
+                  {tPublicStoryPage('errors.contentNotAvailableDesc')}
                 </p>
               </div>
             </div>
@@ -306,10 +307,10 @@ export default function PublicStoryPage() {
           <div className="max-w-4xl mx-auto">
             <div className="bg-gradient-to-r from-blue-50 to-purple-50 rounded-lg p-6 border border-blue-200 print:hidden">
               <h3 className="text-xl font-bold text-gray-900 mb-3 text-center">
-                {t('storyComplete.enjoyedTitle')}
+                {tPublicStoryPage('storyComplete.enjoyedTitle')}
               </h3>
               <p className="text-gray-700 text-center mb-6">
-                {t('storyComplete.enjoyedDesc')}
+                {tPublicStoryPage('storyComplete.enjoyedDesc')}
               </p>
               
               <div className="flex flex-col sm:flex-row gap-4 justify-center">
@@ -318,7 +319,7 @@ export default function PublicStoryPage() {
                   className="btn btn-primary flex items-center gap-2"
                 >
                   <FiEdit3 className="w-4 h-4" />
-                  {t('actions.createOwnStory')}
+                  {tPublicStoryPage('actions.createOwnStory')}
                 </a>
                 
                 <a
@@ -326,7 +327,7 @@ export default function PublicStoryPage() {
                   className="btn btn-secondary flex items-center gap-2"
                 >
                   <FiPrinter className="w-4 h-4" />
-                  {t('actions.orderPrintedBook')}
+                  {tPublicStoryPage('actions.orderPrintedBook')}
                 </a>
               </div>
             </div>

--- a/src/app/[locale]/s/[token]/edit/page.tsx
+++ b/src/app/[locale]/s/[token]/edit/page.tsx
@@ -8,7 +8,7 @@ export default function SharedStoryEditPage() {
   const params = useParams<{ token?: string }>();
   const router = useRouter();
   const locale = useLocale();
-  const t = useTranslations('common');
+  const tCommon = useTranslations('common');
   const token = (params?.token as string | undefined) ?? '';
 
   useEffect(() => {
@@ -21,7 +21,7 @@ export default function SharedStoryEditPage() {
     <div className="min-h-screen flex items-center justify-center">
       <div className="text-center space-y-4">
         <div className="loading loading-spinner loading-lg text-primary"></div>
-        <h2 className="text-xl font-semibold">{t('Loading.redirectingToSharedStory')}</h2>
+        <h2 className="text-xl font-semibold">{tCommon('Loading.redirectingToSharedStory')}</h2>
       </div>
     </div>
   );

--- a/src/components/AudioPlayer/AudioChapterList.tsx
+++ b/src/components/AudioPlayer/AudioChapterList.tsx
@@ -15,7 +15,7 @@ const defaultFormatDuration = (seconds: number): string => {
   return `${minutes}:${remainingSeconds.toString().padStart(2, '0')}`;
 };
 
-export function AudioChapterList({ 
+export function AudioChapterList({
   chapters,
   currentlyPlaying,
   audioProgress,
@@ -25,7 +25,7 @@ export function AudioChapterList({
   stopAudio,
   formatDuration = defaultFormatDuration
 }: AudioChapterListProps) {
-  const t = useTranslations('PublicStoryPage');
+  const tPublicStoryPage = useTranslations('PublicStoryPage');
 
   return (
     <div className="space-y-4">
@@ -37,7 +37,7 @@ export function AudioChapterList({
               {chapter.imageUri ? (
                 <Image
                   src={chapter.imageUri}
-                  alt={t('listen.chapterImageAlt', { number: index + 1 })}
+                  alt={tPublicStoryPage('listen.chapterImageAlt', { number: index + 1 })}
                   className="w-16 h-16 object-cover rounded-lg"
                   width={64}
                   height={64}
@@ -60,7 +60,7 @@ export function AudioChapterList({
               </h3>
               {chapter.duration > 0 && (
                 <p className="text-sm text-gray-600">
-                  {t('listen.duration', { duration: formatDuration(chapter.duration) })}
+                  {tPublicStoryPage('listen.duration', { duration: formatDuration(chapter.duration) })}
                 </p>
               )}
 
@@ -88,14 +88,14 @@ export function AudioChapterList({
                   <button
                     onClick={() => pauseAudio(index)}
                     className="btn btn-circle btn-primary btn-sm"
-                    title={t('listen.controls.pause')}
+                    title={tPublicStoryPage('listen.controls.pause')}
                   >
                     <FiPause className="w-4 h-4" />
                   </button>
                   <button
                     onClick={() => stopAudio(index)}
                     className="btn btn-circle btn-outline btn-sm"
-                    title={t('listen.controls.stop')}
+                    title={tPublicStoryPage('listen.controls.stop')}
                   >
                     <FiSquare className="w-3 h-3" />
                   </button>
@@ -104,7 +104,7 @@ export function AudioChapterList({
                 <button
                   onClick={() => playAudio(index)}
                   className="btn btn-circle btn-primary btn-sm"
-                  title={t('listen.controls.play')}
+                  title={tPublicStoryPage('listen.controls.play')}
                 >
                   <FiPlay className="w-4 h-4 ml-0.5" />
                 </button>

--- a/src/i18n/request.ts
+++ b/src/i18n/request.ts
@@ -11,7 +11,6 @@ export default getRequestConfig(async ({ requestLocale }) => {
   const [
     commonMessages,
     authMessages,
-    publicPagesMessages,
     privacyPolicyMessages,
     pricingMessages,
     storyStepsMessages,
@@ -34,7 +33,6 @@ export default getRequestConfig(async ({ requestLocale }) => {
   ] = await Promise.all([
     import(`../messages/${locale}/common.json`).then(module => module.default),
     import(`../messages/${locale}/auth.json`).then(module => module.default),
-    import(`../messages/${locale}/publicPages.json`).then(module => module.default),
     import(`../messages/${locale}/privacy-policy.json`).then(module => module.default),
     import(`../messages/${locale}/pricing.json`).then(module => module.default),
     import(`../messages/${locale}/storySteps.json`).then(module => module.default),
@@ -77,7 +75,6 @@ export default getRequestConfig(async ({ requestLocale }) => {
       ...sharedStoryPageMessages,
       ...blogMessages,
       ...blogPostMessages,
-      publicPages: publicPagesMessages,
       privacyPolicy: privacyPolicyMessages,
       pricing: pricingMessages,
       storySteps: storyStepsMessages


### PR DESCRIPTION
## Summary
- rename public story translation hooks to `tPublicStoryPage` and `tCommon`
- load PublicStoryPage namespace directly in i18n request config
- use dedicated PublicStoryPage listen strings

## Testing
- `npm test` *(fails: Cannot find module '/workspace/Mythoria-webapp/scripts/smoke-test.js')*
- `npm run lint` *(fails: next: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d2d8dc0548328b38be19c3d3f1b5e