### PR TITLE
test: add normalization and image URL utility tests

### DIFF
--- a/src/db/aiEditService.test.ts
+++ b/src/db/aiEditService.test.ts
@@ -24,7 +24,11 @@ describe('aiEditService.checkEditPermission', () => {
 describe('aiEditService.recordSuccessfulEdit', () => {
   it('deducts credits when required and records edit', async () => {
     jest.spyOn(aiEditService, 'calculateRequiredCredits').mockResolvedValue(2);
-    const deductSpy = jest.spyOn(creditService, 'deductCredits').mockResolvedValue({} as any);
+    const deductSpy = jest
+      .spyOn(creditService, 'deductCredits')
+      .mockResolvedValue(
+        {} as unknown as Awaited<ReturnType<typeof creditService.deductCredits>>,
+      );
     const values = jest.fn().mockResolvedValue([]);
     (db.insert as jest.Mock).mockReturnValue({ values });
 

--- a/src/db/creditService.test.ts
+++ b/src/db/creditService.test.ts
@@ -24,7 +24,9 @@ describe("creditService.deductCredits", () => {
     jest.spyOn(creditService, "canAfford").mockResolvedValue(true);
     const addSpy = jest
       .spyOn(creditService, "addCreditEntry")
-      .mockResolvedValue({} as any);
+      .mockResolvedValue(
+        {} as unknown as Awaited<ReturnType<typeof creditService.addCreditEntry>>,
+      );
 
     await creditService.deductCredits("user", 10, "eBookGeneration", "story1");
 
@@ -41,7 +43,9 @@ describe("creditService.addCredits", () => {
   it("delegates to addCreditEntry", async () => {
     const addSpy = jest
       .spyOn(creditService, "addCreditEntry")
-      .mockResolvedValue({} as any);
+      .mockResolvedValue(
+        {} as unknown as Awaited<ReturnType<typeof creditService.addCreditEntry>>,
+      );
     await creditService.addCredits("user", 20, "creditPurchase", "p1");
     expect(addSpy).toHaveBeenCalledWith(
       "user",

--- a/src/db/services/payment.test.ts
+++ b/src/db/services/payment.test.ts
@@ -1,4 +1,4 @@
-import { paymentService } from "./payment";
+import { paymentService, type CreditPackage } from "./payment";
 
 describe("paymentService.calculateOrderTotal", () => {
   it("calculates totals for valid packages", async () => {
@@ -6,10 +6,10 @@ describe("paymentService.calculateOrderTotal", () => {
       .spyOn(paymentService, "getCreditPackage")
       .mockImplementation(async (id) => {
         if (id === 1) {
-          return { id: 1, credits: 100, price: 10 } as any;
+          return { id: 1, credits: 100, price: 10 } as CreditPackage;
         }
         if (id === 2) {
-          return { id: 2, credits: 200, price: 18 } as any;
+          return { id: 2, credits: 200, price: 18 } as CreditPackage;
         }
         return undefined;
       });

--- a/src/utils/enum-normalizers.test.ts
+++ b/src/utils/enum-normalizers.test.ts
@@ -1,0 +1,75 @@
+import {
+  normalizeTargetAudience,
+  normalizeNovelStyle,
+  normalizeGraphicalStyle,
+  normalizeStoryEnums,
+} from '@/utils/enum-normalizers';
+import {
+  TargetAudience,
+  NovelStyle,
+  GraphicalStyle,
+} from '@/types/story-enums';
+
+describe('normalizeTargetAudience', () => {
+  it('maps common synonyms to enum values', () => {
+    expect(normalizeTargetAudience('toddlers')).toBe(TargetAudience.CHILDREN_0_2);
+    expect(normalizeTargetAudience('tweens')).toBe(TargetAudience.CHILDREN_11_14);
+    expect(normalizeTargetAudience('teenagers')).toBe(TargetAudience.YOUNG_ADULT_15_17);
+    expect(normalizeTargetAudience('adults')).toBe(TargetAudience.ADULT_18_PLUS);
+  });
+
+  it('infers audience from age numbers', () => {
+    expect(normalizeTargetAudience('for 5 year olds')).toBe(TargetAudience.CHILDREN_3_6);
+    expect(normalizeTargetAudience('for 8 year olds')).toBe(TargetAudience.CHILDREN_7_10);
+  });
+
+  it('defaults to children_3-6 when unknown', () => {
+    expect(normalizeTargetAudience('unknown group')).toBe(TargetAudience.CHILDREN_3_6);
+  });
+});
+
+describe('normalizeNovelStyle', () => {
+  it('maps style synonyms', () => {
+    expect(normalizeNovelStyle('sci-fi')).toBe(NovelStyle.SCIENCE_FICTION);
+    expect(normalizeNovelStyle('fairy tale')).toBe(NovelStyle.FAIRY_TALE);
+    expect(normalizeNovelStyle('memoir')).toBe(NovelStyle.BIOGRAPHY);
+    expect(normalizeNovelStyle('funny')).toBe(NovelStyle.COMEDY);
+  });
+
+  it('defaults to adventure when unknown', () => {
+    expect(normalizeNovelStyle('unknown style')).toBe(NovelStyle.ADVENTURE);
+  });
+});
+
+describe('normalizeGraphicalStyle', () => {
+  it('maps graphical style synonyms', () => {
+    expect(normalizeGraphicalStyle('comic')).toBe(GraphicalStyle.COMIC_BOOK);
+    expect(normalizeGraphicalStyle('pixar style')).toBe(GraphicalStyle.PIXAR_STYLE);
+    expect(normalizeGraphicalStyle('watercolour')).toBe(GraphicalStyle.WATERCOLOR);
+    expect(normalizeGraphicalStyle('hand-drawn')).toBe(GraphicalStyle.HAND_DRAWN);
+  });
+
+  it('defaults to cartoon when unknown', () => {
+    expect(normalizeGraphicalStyle('unknown style')).toBe(GraphicalStyle.CARTOON);
+  });
+});
+
+describe('normalizeStoryEnums', () => {
+  it('normalizes all enum fields in an object', () => {
+    const input = {
+      targetAudience: 'teens',
+      novelStyle: 'sci-fi',
+      graphicalStyle: 'comic',
+      other: 'keep',
+    };
+
+    const result = normalizeStoryEnums(input);
+
+    expect(result).toEqual({
+      targetAudience: TargetAudience.YOUNG_ADULT_15_17,
+      novelStyle: NovelStyle.SCIENCE_FICTION,
+      graphicalStyle: GraphicalStyle.COMIC_BOOK,
+      other: 'keep',
+    });
+  });
+});

--- a/src/utils/image-url.test.ts
+++ b/src/utils/image-url.test.ts
@@ -1,0 +1,56 @@
+import {
+  toAbsoluteImageUrl,
+  toRelativeImagePath,
+  formatImageUrl,
+} from '@/utils/image-url';
+
+const BASE = 'https://storage.googleapis.com/mythoria-generated-stories';
+
+describe('toAbsoluteImageUrl', () => {
+  it('returns null for falsy paths', () => {
+    expect(toAbsoluteImageUrl(null)).toBeNull();
+    expect(toAbsoluteImageUrl('')).toBeNull();
+  });
+
+  it('passes through absolute URLs', () => {
+    const url = 'https://example.com/test.png';
+    expect(toAbsoluteImageUrl(url)).toBe(url);
+  });
+
+  it('converts relative paths', () => {
+    expect(toAbsoluteImageUrl('story/img.png')).toBe(`${BASE}/story/img.png`);
+  });
+
+  it('handles leading slashes', () => {
+    expect(toAbsoluteImageUrl('/root.png')).toBe(`${BASE}//root.png`);
+  });
+
+  it('formatImageUrl alias works', () => {
+    expect(formatImageUrl('alias/test.jpg')).toBe(`${BASE}/alias/test.jpg`);
+  });
+});
+
+describe('toRelativeImagePath', () => {
+  it('returns null for falsy input', () => {
+    expect(toRelativeImagePath(null)).toBeNull();
+    expect(toRelativeImagePath('')).toBeNull();
+  });
+
+  it('passes through relative paths', () => {
+    expect(toRelativeImagePath('story/img.png')).toBe('story/img.png');
+  });
+
+  it('converts absolute storage URLs', () => {
+    const rel = 'story/img.png';
+    expect(toRelativeImagePath(`${BASE}/${rel}`)).toBe(rel);
+  });
+
+  it('returns external URLs unchanged', () => {
+    const external = 'https://example.com/other.png';
+    expect(toRelativeImagePath(external)).toBe(external);
+  });
+
+  it('leaves base URL without path unchanged', () => {
+    expect(toRelativeImagePath(BASE)).toBe(BASE);
+  });
+});

--- a/src/utils/imageUtils.test.ts
+++ b/src/utils/imageUtils.test.ts
@@ -2,12 +2,12 @@ import { extractStoryImages } from '@/utils/imageUtils';
 
 describe('extractStoryImages', () => {
   it('groups images by type and sorts versions', () => {
-    const data = {
+    const data: Record<string, { url: string }> = {
       'frontcover_v001.png': { url: 'https://storage.googleapis.com/b/frontcover_v001.png' },
       'frontcover_v002.png': { url: 'https://storage.googleapis.com/b/frontcover_v002.png' },
       'chapter_1.png': { url: 'https://storage.googleapis.com/b/chapter_1.png' },
       'chapter_1_v002.png': { url: 'https://storage.googleapis.com/b/chapter_1_v002.png' },
-    } as any;
+    };
 
     const images = extractStoryImages(data);
     expect(images[0].type).toBe('frontcover');


### PR DESCRIPTION
## Summary
- add comprehensive tests for enum normalizers covering audience, novel style, graphical style and object normalization
- add edge case coverage for image URL utilities
- replace `any` casts in existing tests with typed mocks for lint compliance

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68a3bbd7a5808328b647b3efcacf5c04