### PR TITLE
refactor: centralize locale handling and supported locales

### DIFF
--- a/src/app/api/auth/update-locale/route.ts
+++ b/src/app/api/auth/update-locale/route.ts
@@ -3,7 +3,7 @@ import { auth } from '@clerk/nextjs/server';
 import { db } from '@/db';
 import { authors } from '@/db/schema';
 import { eq } from 'drizzle-orm';
-import { normalizePreferredLocale } from '@/utils/locale-utils';
+import { normalizeLocale } from '@/utils/locale-utils';
 
 export async function POST(req: Request) {
   try {
@@ -20,7 +20,7 @@ export async function POST(req: Request) {
     // Parse request body
   const body = await req.json();
   const preferredLocaleInput = body?.preferredLocale as string | undefined;
-  const normalized = normalizePreferredLocale(preferredLocaleInput);
+  const normalized = normalizeLocale(preferredLocaleInput);
 
   // (Implicit validation via normalization) If input was invalid we still coerce to 'en-US'.
   // If you want to reject unknown locales explicitly, add a guard here.

--- a/src/app/api/payments/mbway/route.ts
+++ b/src/app/api/payments/mbway/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getCurrentAuthor } from '@/lib/auth';
 import { paymentService } from '@/db/services';
+import { normalizeLocale } from '@/utils/locale-utils';
 
 interface Manager {
   email: string;
@@ -24,20 +25,6 @@ function getTicketNumber(uuid: string): string {
   }
   // Fallback to first 4 characters if UUID format is unexpected
   return uuid.substring(0, 4).toUpperCase();
-}
-
-// Helper function to normalize locale
-function normalizeLocale(locale?: string): string {
-  if (!locale) return 'en-US';
-  
-  const localeMap: Record<string, string> = {
-    'en': 'en-US',
-    'pt': 'pt-PT',
-    'en-US': 'en-US',
-    'pt-PT': 'pt-PT',
-  };
-  
-  return localeMap[locale.toLowerCase()] || 'en-US';
 }
 
 export async function POST(request: NextRequest) {

--- a/src/app/api/webhooks/route.ts
+++ b/src/app/api/webhooks/route.ts
@@ -5,17 +5,8 @@ import { NextResponse } from 'next/server';
 import { db } from '@/db';
 import { authors } from '@/db/schema';
 import { eq } from 'drizzle-orm';
+import { detectUserLocaleFromEmail } from '@/utils/locale-utils';
 import { sendWelcomeNotification } from '@/lib/notifications/welcome';
-
-// Basic locale detection from email domain (fallback logic). This mirrors earlier heuristic
-// and should be replaced if/when a more robust detection source is available.
-function detectUserLocale(email: string): string {
-  const lower = email.toLowerCase();
-  if (lower.endsWith('.pt') || lower.includes('.pt') || lower.endsWith('.pt">')) return 'pt-PT';
-  if (lower.endsWith('.es') || lower.includes('.es')) return 'es-ES';
-  return 'en-US';
-}
-
 
 export async function POST(req: Request) {
   // Get the headers
@@ -106,7 +97,7 @@ async function handleUserCreated(evt: WebhookEvent) {
 
   const userName = `${first_name || ''} ${last_name || ''}`.trim() || 'Anonymous User';
 
-  const userLocale = detectUserLocale(primaryEmail.email_address);
+  const userLocale = detectUserLocaleFromEmail(primaryEmail.email_address);
 
   try {
     // Try to insert new user first

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { enUS, ptPT, esES } from '@clerk/localizations';
 import GoogleAnalytics from "../components/GoogleAnalytics";
 import AnalyticsProvider from "../components/AnalyticsProvider";
 import { headers } from 'next/headers';
+import { SUPPORTED_LOCALES } from '@/config/locales';
 import "./globals.css";
 
 // Base metadata for non-localized routes only
@@ -22,14 +23,17 @@ export default async function RootLayout({
   // Get the pathname from headers to determine locale
   const headersList = await headers();
   const pathname = headersList.get('x-pathname') || '';
-  
+
   // Extract locale from pathname (e.g., /en-US/sign-in -> en-US)
   const localeMatch = pathname.match(/^\/([a-z]{2}-[A-Z]{2})/);
-  const locale = localeMatch ? localeMatch[1] : 'en-US';
-  
+  let locale = localeMatch ? localeMatch[1] : 'en-US';
+  if (!SUPPORTED_LOCALES.includes(locale)) {
+    locale = SUPPORTED_LOCALES[0] || 'en-US';
+  }
+
   // Select appropriate Clerk localization
-  const getClerkLocalization = (locale: string) => {
-    switch (locale) {
+  const getClerkLocalization = (loc: string) => {
+    switch (loc) {
       case 'pt-PT':
         return ptPT;
       case 'es-ES':
@@ -39,14 +43,14 @@ export default async function RootLayout({
         return enUS;
     }
   };
-  
+
   const clerkLocalization = getClerkLocalization(locale);
-  
+
   return (
     <ClerkProvider localization={clerkLocalization}>
       <html lang={locale} data-theme="autumn">
         <head>
-          <GoogleAnalytics 
+          <GoogleAnalytics
             measurementId={process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID || 'G-86D0QFW197'}
             googleAdsId={process.env.NEXT_PUBLIC_GOOGLE_ADS_ID}
             googleTagId={process.env.NEXT_PUBLIC_GOOGLE_TAG_ID}

--- a/src/components/LanguageSwitcher.tsx
+++ b/src/components/LanguageSwitcher.tsx
@@ -2,7 +2,7 @@
 
 import { useLocale } from 'next-intl';
 import { usePathname } from 'next/navigation';
-import { routing } from '@/i18n/routing';
+import { SUPPORTED_LOCALES } from '@/config/locales';
 
 const LanguageSwitcher = () => {
   const locale = useLocale();
@@ -10,22 +10,22 @@ const LanguageSwitcher = () => {
   const handleLanguageChange = (newLocale: string) => {
     // Store the language preference in localStorage
     localStorage.setItem('mythoria-locale', newLocale);
-    
+
     // Remove the current locale from the pathname
-  const safePathname = pathname || window.location.pathname;
-  const segments = safePathname.split('/');
-    if (routing.locales.includes(segments[1] as (typeof routing.locales)[number])) {
+    const safePathname = pathname || window.location.pathname;
+    const segments = safePathname.split('/');
+    if (SUPPORTED_LOCALES.includes(segments[1])) {
       segments[1] = newLocale;
     } else {
       segments.unshift('', newLocale);
     }
-    
+
     const newPath = segments.join('/');
     window.location.href = newPath;
   };
 
-  const getLanguageLabel = (locale: string) => {
-    switch (locale) {
+  const getLanguageLabel = (loc: string) => {
+    switch (loc) {
       case 'en-US':
         return 'EN';
       case 'pt-PT':
@@ -33,7 +33,7 @@ const LanguageSwitcher = () => {
       case 'es-ES':
         return 'ES';
       default:
-        return locale.toUpperCase();
+        return loc.toUpperCase();
     }
   };
 
@@ -46,7 +46,7 @@ const LanguageSwitcher = () => {
         <span className="hidden sm:inline ml-1">{getLanguageLabel(locale)}</span>
       </label>
       <ul tabIndex={0} className="dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-32">
-        {routing.locales.map((availableLocale) => (
+        {SUPPORTED_LOCALES.map((availableLocale) => (
           <li key={availableLocale}>
             <button
               onClick={() => handleLanguageChange(availableLocale)}
@@ -55,9 +55,9 @@ const LanguageSwitcher = () => {
               }`}
             >
               <span>
-                {availableLocale === 'en-US' ? 'English' : 
-                 availableLocale === 'pt-PT' ? 'Português' : 
-                 availableLocale === 'es-ES' ? 'Español' : 
+                {availableLocale === 'en-US' ? 'English' :
+                 availableLocale === 'pt-PT' ? 'Português' :
+                 availableLocale === 'es-ES' ? 'Español' :
                  availableLocale}
               </span>
               <span className="text-xs opacity-60">{getLanguageLabel(availableLocale)}</span>

--- a/src/config/locales.ts
+++ b/src/config/locales.ts
@@ -1,0 +1,5 @@
+const DEFAULT_SUPPORTED_LOCALES = ['en-US', 'pt-PT', 'es-ES'] as const;
+
+export const SUPPORTED_LOCALES = (process.env.NEXT_PUBLIC_SUPPORTED_LOCALES?.split(',').map(l => l.trim()) || [...DEFAULT_SUPPORTED_LOCALES]) as readonly string[];
+
+export type SupportedLocale = typeof DEFAULT_SUPPORTED_LOCALES[number];

--- a/src/db/services.ts
+++ b/src/db/services.ts
@@ -5,7 +5,7 @@ import { ClerkUserForSync } from "@/types/clerk";
 import { pricingService } from "./services/pricing";
 import { CharacterRole, CharacterAge, isValidCharacterAge } from "../types/character-enums";
 import { toAbsoluteImageUrl, toRelativeImagePath } from "../utils/image-url";
-import { normalizePreferredLocale, detectUserLocaleFromEmail } from '@/utils/locale-utils';
+import { normalizeLocale, detectUserLocaleFromEmail } from '@/utils/locale-utils';
 
 // Export payment service
 export { paymentService } from "./services/payment";
@@ -14,7 +14,7 @@ export { blogService } from './services/blog';
 
 // Author operations
 export const authorService = {  async createAuthor(authorData: { clerkUserId: string; email: string; displayName: string; preferredLocale?: string }) {
-    const normalizedLocale = normalizePreferredLocale(authorData.preferredLocale);
+    const normalizedLocale = normalizeLocale(authorData.preferredLocale);
     const [author] = await db.insert(authors).values({
       clerkUserId: authorData.clerkUserId,
       email: authorData.email,
@@ -57,7 +57,7 @@ export const authorService = {  async createAuthor(authorData: { clerkUserId: st
         displayName: this.buildDisplayName(clerkUser),
         lastLoginAt: currentTime,
         createdAt: currentTime,
-        preferredLocale: normalizePreferredLocale(detectedLocale),
+        preferredLocale: normalizeLocale(detectedLocale),
         ...(primaryPhone?.phoneNumber && { mobilePhone: primaryPhone.phoneNumber })
       };
 
@@ -93,7 +93,7 @@ export const authorService = {  async createAuthor(authorData: { clerkUserId: st
                   clerkUserId: clerkUser.id, // Update to new clerkId
                   displayName: this.buildDisplayName(clerkUser),
                   lastLoginAt: currentTime,
-                  preferredLocale: normalizePreferredLocale(detectedLocale),
+                  preferredLocale: normalizeLocale(detectedLocale),
                   ...(primaryPhone?.phoneNumber && { mobilePhone: primaryPhone.phoneNumber })
                 })
                 .where(eq(authors.email, newAuthorData.email))

--- a/src/db/services/blog.ts
+++ b/src/db/services/blog.ts
@@ -1,9 +1,10 @@
 import { db } from '../index';
 import { blogPosts, blogPostTranslations } from '../schema/blog';
 import { and, asc, desc, eq, lt, gt } from 'drizzle-orm';
+import { SUPPORTED_LOCALES, SupportedLocale } from '@/config/locales';
 
-export const BLOG_SUPPORTED_LOCALES = ['en-US', 'pt-PT', 'es-ES'] as const;
-export type BlogLocale = typeof BLOG_SUPPORTED_LOCALES[number];
+export const BLOG_SUPPORTED_LOCALES = SUPPORTED_LOCALES;
+export type BlogLocale = SupportedLocale;
 
 export interface CreatePostInput {
   slugBase: string;

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -1,22 +1,19 @@
 import {defineRouting} from 'next-intl/routing';
 import {createNavigation} from 'next-intl/navigation';
- 
+import { SUPPORTED_LOCALES, SupportedLocale } from '@/config/locales';
+
 export const routing = defineRouting({
-  // A list of all locales that are supported
-  locales: ['en-US', 'pt-PT', 'es-ES'],
- 
-  // Used when no locale matches
-  defaultLocale: 'en-US'
+  locales: SUPPORTED_LOCALES as SupportedLocale[],
+  defaultLocale: (SUPPORTED_LOCALES[0] as SupportedLocale) || 'en-US'
 });
 
-// Type for supported locales
-export type Locale = typeof routing.locales[number];
+export type Locale = SupportedLocale;
 
 // Helper function to check if a string is a valid locale
-export function isValidLocale(locale: string): locale is Locale {
-  return routing.locales.includes(locale as Locale);
+export function isValidLocale(locale: string): locale is SupportedLocale {
+  return SUPPORTED_LOCALES.includes(locale);
 }
- 
+
 // Lightweight wrappers around Next.js' navigation APIs
 // that will consider the routing configuration
 export const {Link, redirect, usePathname, useRouter} =

--- a/src/utils/locale-utils.ts
+++ b/src/utils/locale-utils.ts
@@ -1,10 +1,10 @@
+import { SUPPORTED_LOCALES, SupportedLocale } from '@/config/locales';
+
 // Lightweight locale normalization utilities
 // Maps short or variant locale codes to canonical BCP47 tags we support.
 
-export type SupportedLocale = 'en-US' | 'pt-PT';
-
 // Normalize preferred locale input (accepts undefined, short codes, underscores, case variants)
-export function normalizePreferredLocale(locale?: string): SupportedLocale {
+export function normalizeLocale(locale?: string): SupportedLocale {
   if (!locale) return 'en-US';
   const lower = locale.toLowerCase().replace('_', '-');
   switch (lower) {
@@ -14,6 +14,9 @@ export function normalizePreferredLocale(locale?: string): SupportedLocale {
     case 'pt':
     case 'pt-pt':
       return 'pt-PT';
+    case 'es':
+    case 'es-es':
+      return 'es-ES';
     default:
       return 'en-US';
   }
@@ -25,5 +28,8 @@ export function detectUserLocaleFromEmail(email?: string | null): SupportedLocal
   if (!email) return 'en-US';
   const lower = email.toLowerCase();
   if (lower.endsWith('.pt') || lower.includes('.pt')) return 'pt-PT';
+  if (lower.endsWith('.es') || lower.includes('.es')) return 'es-ES';
   return 'en-US';
 }
+
+export { SUPPORTED_LOCALES };


### PR DESCRIPTION
## Summary
- extract `normalizeLocale` and email-based detection into shared `locale-utils`
- derive supported locales from `NEXT_PUBLIC_SUPPORTED_LOCALES` and reuse across routing, blog, language switcher, and layout
- replace duplicated locale logic in MB Way payments and webhooks

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68aeeb7e466c8328b842fb0abc74ae87