### PR TITLE
fix(i18n): translate remaining French strings

### DIFF
--- a/src/messages/fr-FR/StoryRating.json
+++ b/src/messages/fr-FR/StoryRating.json
@@ -1,36 +1,36 @@
 {
   "StoryRating": {
-    "title": "Rate this story",
-    "titleUpdate": "Update Your Rating",
-    "currentRating": "Current Rating",
-    "basedOnRatings": "Based on {count} rating{plural}",
-    "clickToRate": "Click to rate {count} star{plural}",
-    "noRatingsYet": "No ratings yet",
-    "yourCurrentRating": "Your current rating",
-    "youSelected": "You selected:",
-    "starTooltip": "Rate {count} star{plural}",
+    "title": "Évaluez cette histoire",
+    "titleUpdate": "Mettez à jour votre note",
+    "currentRating": "Note actuelle",
+    "basedOnRatings": "Basé sur {count} note{plural}",
+    "clickToRate": "Cliquez pour noter {count} étoile{plural}",
+    "noRatingsYet": "Pas encore de note",
+    "yourCurrentRating": "Votre note actuelle",
+    "youSelected": "Vous avez sélectionné :",
+    "starTooltip": "Noter {count} étoile{plural}",
     "feedback": {
-      "title": "What could we improve? (Optional)",
-      "placeholder": "Your feedback helps us create better stories...",
-      "includeNameLabel": "Allow the author to see my name with this feedback"
+      "title": "Que pourrions-nous améliorer ? (facultatif)",
+      "placeholder": "Vos retours nous aident à créer de meilleures histoires...",
+      "includeNameLabel": "Permettre à l'auteur de voir mon nom avec ce commentaire"
     },
     "buttons": {
-      "cancel": "Cancel",
-      "submitRating": "Submit Rating",
-      "updateRating": "Update Rating",
-      "submitting": "Submitting..."
+      "cancel": "Annuler",
+      "submitRating": "Soumettre la note",
+      "updateRating": "Mettre à jour la note",
+      "submitting": "Envoi..."
     },
     "success": {
-      "title": "Thank you for your rating!",
-      "titleUpdated": "Rating Updated!",
-      "message": "Your feedback helps us improve our stories.",
-      "messageUpdated": "Your rating has been updated successfully!"
+      "title": "Merci pour votre note !",
+      "titleUpdated": "Note mise à jour !",
+      "message": "Vos retours nous aident à améliorer nos histoires.",
+      "messageUpdated": "Votre note a bien été mise à jour !"
     },
-    "submittingMessage": "Submitting your rating...",
+    "submittingMessage": "Envoi de votre note...",
     "errors": {
-      "serviceUnavailable": "The rating system is currently being set up. Please try again in a few minutes.",
-      "submitFailed": "Failed to submit rating",
-      "generic": "An error occurred"
+      "serviceUnavailable": "Le système de notation est en cours de configuration. Veuillez réessayer dans quelques minutes.",
+      "submitFailed": "Échec de l'envoi de la note",
+      "generic": "Une erreur s'est produite"
     }
   }
 }

--- a/src/messages/fr-FR/StoryReader.json
+++ b/src/messages/fr-FR/StoryReader.json
@@ -1,17 +1,17 @@
 {
   "StoryReader": {
-    "preparing": "Preparing your story...",
-    "startReading": "Start Reading",
-    "listen": "Listen",
-    "chapterNotFound": "Chapter not found",
-    "chapterNotFoundDescription": "The requested chapter could not be found.",
-    "backToStory": "Back to Story",
-    "storyImaginedBy": "This story was imagined by",
+    "preparing": "Préparation de votre histoire...",
+    "startReading": "Commencer la lecture",
+    "listen": "Écouter",
+    "chapterNotFound": "Chapitre introuvable",
+    "chapterNotFoundDescription": "Le chapitre demandé est introuvable.",
+    "backToStory": "Retour à l'histoire",
+    "storyImaginedBy": "Cette histoire a été imaginée par",
     "storyImaginedByEnd": ".",
-    "craftedWith": "Crafted with:",
-    "byAuthor": "by {authorName}",
+    "craftedWith": "Créée avec :",
+    "byAuthor": "par {authorName}",
     "synopsis": "Synopsis",
-    "tableOfContents": "Table of Contents",
-    "coverAndIntroduction": "Cover & Introduction"
+    "tableOfContents": "Table des matières",
+    "coverAndIntroduction": "Couverture et introduction"
   }
 }


### PR DESCRIPTION
## Summary
- localize story rating UI strings in French
- translate story reader messages to fr-FR

## Testing
- `npm run lint`
- `npx tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68b3569e7554832894109e9f82ed7151