### PR TITLE
refactor(my-stories): extract story row and table hook

### DIFF
--- a/src/components/MyStoriesTable.tsx
+++ b/src/components/MyStoriesTable.tsx
@@ -1,106 +1,48 @@
 'use client';
 
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { useTranslations } from 'next-intl';
 import { useLocale } from 'next-intl';
-import { 
-  FiEdit3, 
-  FiTrash2, 
-  FiShare2,
-  FiChevronUp,
-  FiChevronDown,
-  FiBook,
-  FiPrinter,
-  FiMoreVertical,
-  FiCopy
-} from 'react-icons/fi';
-import { trackStoryManagement } from '../lib/analytics';
+import { FiChevronUp, FiChevronDown } from 'react-icons/fi';
 import ShareModal from './ShareModal';
 import ToastContainer from './ToastContainer';
+import StoryRow from './my-stories/StoryRow';
+import { useStoriesTable } from '@/hooks/useStoriesTable';
+import { Story, SortField } from '@/types/story';
 import { useToast } from '@/hooks/useToast';
-
-interface Story {
-  storyId: string;
-  title: string;
-  status: 'draft' | 'writing' | 'published';
-  storyGenerationStatus?: 'queued' | 'running' | 'failed' | 'completed' | 'cancelled' | null;
-  storyGenerationCompletedPercentage?: number;
-  isPublic?: boolean;
-  slug?: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
-type SortField = 'title' | 'createdAt' | 'updatedAt' | 'status';
-type SortDirection = 'asc' | 'desc';
+import { trackStoryManagement } from '@/lib/analytics';
 
 export default function MyStoriesTable() {
   const tMyStoriesPage = useTranslations('MyStoriesPage');
-  const tCommonShare = useTranslations('Share');
   const tCommonActions = useTranslations('Actions');
-  const locale = useLocale();const [stories, setStories] = useState<Story[]>([]);
-  const [loading, setLoading] = useState(true);
+  const locale = useLocale();
+
+  const {
+    paginatedStories,
+    loading,
+    handleSort,
+    sortField,
+    sortDirection,
+    fetchStories,
+    setStories,
+  } = useStoriesTable();
+
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
   const [storyToDelete, setStoryToDelete] = useState<Story | null>(null);
   const [shareModalOpen, setShareModalOpen] = useState(false);
   const [storyToShare, setStoryToShare] = useState<Story | null>(null);
-  const [openActionMenu, setOpenActionMenu] = useState<string | null>(null);
-  const [menuPosition, setMenuPosition] = useState<{top: number, right: number} | null>(null);
   const { toasts, removeToast, successWithAction, error } = useToast();
-  
-  // Mobile detection
   const [isMobile, setIsMobile] = useState(false);
-  
-  // Sorting state
-  const [sortField, setSortField] = useState<SortField>('createdAt');
-  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
-  useEffect(() => {
-    fetchStories();
-  }, []);
 
-  // Mobile detection effect
   useEffect(() => {
     const checkMobile = () => {
       setIsMobile(window.innerWidth < 768);
     };
-
     checkMobile();
     window.addEventListener('resize', checkMobile);
-    
     return () => window.removeEventListener('resize', checkMobile);
   }, []);
-
-  // Close mobile menu when clicking outside
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      const target = event.target as Element;
-      if (openActionMenu && 
-          !target.closest('.relative') && 
-          !target.closest('[data-story-menu]') &&
-          !target.closest('.fixed')) {
-        setOpenActionMenu(null);
-        setMenuPosition(null);
-      }
-    };
-
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [openActionMenu]);
-
-  const fetchStories = async () => {
-    try {
-      const response = await fetch('/api/my-stories');
-      if (response.ok) {
-        const data = await response.json();
-        setStories(data.stories);
-      }
-    } catch (error) {
-      console.error('Error fetching stories:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
 
   const handleDeleteClick = (story: Story) => {
     setStoryToDelete(story);
@@ -109,34 +51,31 @@ export default function MyStoriesTable() {
 
   const handleDeleteConfirm = async () => {
     if (!storyToDelete) return;
-
     try {
       const response = await fetch(`/api/my-stories/${storyToDelete.storyId}`, {
         method: 'DELETE',
       });
-      
       if (response.ok) {
-        // Track story deletion
         trackStoryManagement.deleted({
           story_id: storyToDelete.storyId,
           story_title: storyToDelete.title,
-          story_status: storyToDelete.status
+          story_status: storyToDelete.status,
         });
-        
-        setStories(stories.filter(s => s.storyId !== storyToDelete.storyId));
+        setStories((prev) => prev.filter((s) => s.storyId !== storyToDelete.storyId));
         setDeleteModalOpen(false);
         setStoryToDelete(null);
       }
-    } catch (error) {
-      console.error('Error deleting story:', error);
+    } catch (err) {
+      console.error('Error deleting story:', err);
     }
-  };  const handleShare = (story: Story) => {
+  };
+
+  const handleShare = (story: Story) => {
     setStoryToShare(story);
     setShareModalOpen(true);
   };
 
   const handlePrint = (story: Story) => {
-    // Navigate to the print order page
     window.location.href = `/${locale}/stories/print/${story.storyId}`;
   };
 
@@ -145,133 +84,29 @@ export default function MyStoriesTable() {
       const resp = await fetch(`/api/my-stories/${story.storyId}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-  // Do not send locale when duplicating; language stays same until translation.
-  body: JSON.stringify({ action: 'duplicate' }),
+        body: JSON.stringify({ action: 'duplicate' }),
       });
       if (!resp.ok) {
         throw new Error(`Duplicate failed: ${resp.status}`);
       }
-  const data = await resp.json();
-  const newStory = data.story as Story;
-  // Refresh list to include new story
-  await fetchStories();
-  // Localized toast with link
-  const link = `/${locale}/stories/read/${newStory.storyId}`;
-  successWithAction(tMyStoriesPage('duplicate.success'), tCommonActions('open'), link);
+      const data = await resp.json();
+      const newStory = data.story as Story;
+      await fetchStories();
+      const link = `/${locale}/stories/read/${newStory.storyId}`;
+      successWithAction(tMyStoriesPage('duplicate.success'), tCommonActions('open'), link);
     } catch (e) {
       console.error('Error duplicating story:', e);
       error(tMyStoriesPage('duplicate.error'));
     }
   };
 
-  // Filtering and sorting functions
-  const handleSort = (field: SortField) => {
-    if (sortField === field) {
-      setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
-    } else {
-      setSortField(field);
-      setSortDirection('asc');
-    }
-  };
-
   const getSortIcon = (field: SortField) => {
     if (sortField !== field) return null;
-    return sortDirection === 'asc' ? 
-      <FiChevronUp className="w-4 h-4 inline ml-1" /> : 
-      <FiChevronDown className="w-4 h-4 inline ml-1" />;
-  };
-
-  // Sorted stories
-  const sortedStories = useMemo(() => {
-    const sorted = [...stories];
-
-    sorted.sort((a, b) => {
-      let aValue: string | number;
-      let bValue: string | number;
-
-      switch (sortField) {
-        case 'title':
-          aValue = a.title.toLowerCase();
-          bValue = b.title.toLowerCase();
-          break;
-        case 'createdAt':
-          aValue = new Date(a.createdAt).getTime();
-          bValue = new Date(b.createdAt).getTime();
-          break;
-        case 'updatedAt':
-          aValue = new Date(a.updatedAt).getTime();
-          bValue = new Date(b.updatedAt).getTime();
-          break;
-        case 'status':
-          aValue = a.status;
-          bValue = b.status;
-          break;
-        default:
-          return 0;
-      }
-
-      if (aValue < bValue) {
-        return sortDirection === 'asc' ? -1 : 1;
-      }
-      if (aValue > bValue) {
-        return sortDirection === 'asc' ? 1 : -1;
-      }
-      return 0;
-    });
-
-    return sorted;
-  }, [stories, sortField, sortDirection]);
-
-  // Date formatting respecting locale rules.
-  // Desktop: day+month+2-digit year using locale ordering (e.g., pt-PT -> 28/08/25, en-US -> 08/28/25)
-  // Mobile: only numeric month/day (order depends on locale) (e.g., pt-PT -> 28/08, en-US -> 08/28)
-  const desktopDateFormatter = useMemo(() => new Intl.DateTimeFormat(locale, {
-    day: '2-digit',
-    month: '2-digit',
-    year: '2-digit'
-  }), [locale]);
-  const mobileDateFormatter = useMemo(() => new Intl.DateTimeFormat(locale, {
-    day: '2-digit',
-    month: '2-digit'
-  }), [locale]);
-
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    if (isNaN(date.getTime())) return '-';
-    return isMobile ? mobileDateFormatter.format(date) : desktopDateFormatter.format(date);
-  };
-  const getStatusBadgeClass = (status: string) => {
-    switch (status) {
-      case 'draft':
-        return 'badge badge-secondary';
-      case 'writing':
-        return 'badge badge-warning';
-      case 'published':
-        return 'badge badge-success';
-      default:
-        return 'badge badge-ghost';
-    }
-  };
-
-  const getGenerationStatusInfo = (story: Story) => {
-    if (!story.storyGenerationStatus) {
-      return null;
-    }
-
-    const statusMap = {
-      queued: { text: tMyStoriesPage('table.status.queued'), class: 'badge-info', icon: '⏳' },
-      running: { text: tMyStoriesPage('table.status.running'), class: 'badge-warning', icon: '🔄' },
-      completed: { text: tMyStoriesPage('table.status.completed'), class: 'badge-success', icon: '✅' },
-      failed: { text: tMyStoriesPage('table.status.failed'), class: 'badge-error', icon: '❌' },
-      cancelled: { text: tMyStoriesPage('table.status.cancelled'), class: 'badge-neutral', icon: '⏹️' },
-    };
-
-    const statusInfo = statusMap[story.storyGenerationStatus];
-    
-    return {
-      ...statusInfo,
-      percentage: story.storyGenerationCompletedPercentage || 0
-    };
+    return sortDirection === 'asc' ? (
+      <FiChevronUp className="w-4 h-4 inline ml-1" />
+    ) : (
+      <FiChevronDown className="w-4 h-4 inline ml-1" />
+    );
   };
 
   if (loading) {
@@ -280,10 +115,11 @@ export default function MyStoriesTable() {
         <span className="loading loading-spinner loading-lg"></span>
       </div>
     );
-  }  return (
+  }
+
+  return (
     <div className="space-y-6">
-      {/* Stories Content */}
-      {stories.length === 0 ? (
+      {paginatedStories.length === 0 ? (
         <div className="text-center py-16 bg-base-200 rounded-lg">
           <div className="max-w-md mx-auto space-y-4">
             <h2 className="text-2xl font-semibold text-base-content">
@@ -298,354 +134,78 @@ export default function MyStoriesTable() {
           </div>
         </div>
       ) : (
-        <><div className="overflow-x-auto overflow-y-visible">
-            <table className="table table-zebra w-full">
-              <thead>
-                <tr>
-                  <th className="px-2 py-1 md:px-4 md:py-2">
-                    <button
-                      className="btn btn-ghost btn-sm p-0 h-auto font-medium text-left justify-start"
-                      onClick={() => handleSort('createdAt')}
-                    >
-                      {tMyStoriesPage('table.date')}
-                      {getSortIcon('createdAt')}
-                    </button>
-                  </th>
-                  <th className="px-2 py-1 md:px-4 md:py-2">
-                    <button
-                      className="btn btn-ghost btn-sm p-0 h-auto font-medium text-left justify-start"
-                      onClick={() => handleSort('title')}
-                    >
-                      {tMyStoriesPage('table.title')}
-                      {getSortIcon('title')}
-                    </button>
-                  </th>
-                  <th className="px-2 py-1 md:px-4 md:py-2">
-                    <button
-                      className="btn btn-ghost btn-sm p-0 h-auto font-medium text-left justify-start"
-                      onClick={() => handleSort('status')}
-                    >
-                      {tMyStoriesPage('table.status.header')}
-                      {getSortIcon('status')}
-                    </button>
-                  </th>
-                  <th className="text-right px-2 py-1 md:px-4 md:py-2">{tMyStoriesPage('table.actions')}</th>
-                </tr>
-              </thead>
-              <tbody>
-                {sortedStories.map((story) => (<tr key={story.storyId}>
-                    <td className="px-2 py-1 md:px-4 md:py-2">{formatDate(story.createdAt)}</td>
-                    <td className="font-medium px-2 py-1 md:px-4 md:py-2">
-                      {story.status === 'published' ? (
-                        <Link 
-                          href={`/${locale}/stories/${story.storyId}`}
-                          className="text-primary hover:text-primary-focus hover:underline cursor-pointer"
-                        >
-                          {story.title}
-                        </Link>
-                      ) : (
-                        <span>{story.title}</span>
-                      )}
-                    </td>
-                    <td className="px-2 py-1 md:px-4 md:py-2 whitespace-nowrap">
-                      <div className="space-y-1">
-                        <span className={`${getStatusBadgeClass(story.status)} badge-sm text-xs whitespace-nowrap`}>
-                          {tMyStoriesPage(`status.${story.status}`)}
-                        </span>
-                        {(() => {
-                          const genStatus = getGenerationStatusInfo(story);
-                          if (genStatus && story.status === 'writing') {
-                            return (
-                              <div className="flex flex-col space-y-1">
-                                <span className={`badge badge-xs ${genStatus.class} whitespace-nowrap`}>
-                                  {genStatus.icon} {genStatus.text}
-                                </span>
-                                {genStatus.percentage > 0 && genStatus.text === 'Generating' && (
-                                  <div className="w-full">
-                                    <progress 
-                                      className="progress progress-primary w-full h-2" 
-                                      value={genStatus.percentage} 
-                                      max="100"
-                                    ></progress>
-                                    <span className="text-xs text-gray-500">{genStatus.percentage}%</span>
-                                  </div>
-                                )}
-                              </div>
-                            );
-                          }
-                          return null;
-                        })()}
-                      </div>
-                    </td>
-                    <td className="pl-2 pr-1 py-1 md:px-4 md:py-2">
-                      {/* Desktop Actions - Hidden on Mobile */}
-                      <div className="hidden md:flex justify-end gap-0.5">
-                        {/* Duplicate action available for any story per requirement (but API restricts to published) */}
-                        <button
-                          className={`btn btn-ghost btn-sm ${story.status !== 'published' ? 'btn-disabled' : ''}`}
-                          onClick={() => story.status === 'published' && handleDuplicate(story)}
-                          title={tMyStoriesPage('actions.duplicate')}
-                          disabled={story.status !== 'published'}
-                        >
-                          <FiCopy className="w-4 h-4" />
-                        </button>
-                        {story.status === 'published' && (
-                          <Link
-                            href={`/${locale}/stories/${story.storyId}`}
-                            className="btn btn-ghost btn-sm text-primary hover:bg-primary hover:text-primary-content"
-                            title="Read Story"
-                          >
-                            <FiBook className="w-4 h-4" />
-                          </Link>
-                        )}
-                        {story.status === 'writing' ? (
-                          <button
-                            className="btn btn-ghost btn-sm btn-disabled"
-                            disabled
-                            title={tCommonShare('tooltips.cannotShareWriting')}
-                          >
-                            <FiShare2 className="w-4 h-4" />
-                          </button>
-                        ) : story.status === 'draft' ? (
-                          <button
-                            className="btn btn-ghost btn-sm btn-disabled"
-                            disabled
-                            title={tCommonShare('tooltips.cannotShareDraft')}
-                          >
-                            <FiShare2 className="w-4 h-4" />
-                          </button>
-                        ) : (
-                          <button
-                            className="btn btn-ghost btn-sm"
-                            onClick={() => handleShare(story)}
-                            title={tMyStoriesPage('actions.share')}
-                          >
-                            <FiShare2 className="w-4 h-4" />
-                          </button>
-                        )}
-                        {/* Print button - only for published stories */}
-                        {story.status === 'published' ? (
-                          <button
-                            className="btn btn-ghost btn-sm"
-                            onClick={() => handlePrint(story)}
-                            title={tMyStoriesPage('actions.print')}
-                          >
-                            <FiPrinter className="w-4 h-4" />
-                          </button>
-                        ) : (
-                          <button
-                            className="btn btn-ghost btn-sm btn-disabled"
-                            disabled
-                            title={tMyStoriesPage('actions.printNotAvailable')}
-                          >
-                            <FiPrinter className="w-4 h-4" />
-                          </button>
-                        )}
-                        {story.status === 'writing' ? (
-                          <button
-                            className="btn btn-ghost btn-sm btn-disabled"
-                            disabled
-                            title="Cannot edit story while it's being written"
-                          >
-                            <FiEdit3 className="w-4 h-4" />
-                          </button>
-                        ) : story.status === 'draft' ? (
-                          <Link
-                            href={`/${locale}/tell-your-story/step-3?edit=${story.storyId}`}
-                            className="btn btn-ghost btn-sm"
-                            title={tMyStoriesPage('actions.edit')}
-                          >
-                            <FiEdit3 className="w-4 h-4" />
-                          </Link>
-                        ) : (
-                          <Link
-                            href={`/${locale}/stories/edit/${story.storyId}`}
-                            className="btn btn-ghost btn-sm"
-                            title={tMyStoriesPage('actions.edit')}
-                          >
-                            <FiEdit3 className="w-4 h-4" />
-                          </Link>
-                        )}
-                        <button
-                          className="btn btn-ghost btn-sm text-error hover:bg-error hover:text-error-content"
-                          onClick={() => handleDeleteClick(story)}
-                          title={tMyStoriesPage('actions.delete')}
-                        >
-                          <FiTrash2 className="w-4 h-4" />
-                        </button>
-                      </div>
-
-                      {/* Mobile Actions - Dropdown Menu */}
-                      <div className="md:hidden relative">
-                        <button
-                          className="btn btn-ghost btn-sm"
-                          data-story-menu={story.storyId}
-                          onClick={(e) => {
-                            const rect = e.currentTarget.getBoundingClientRect();
-                            setMenuPosition({
-                              top: rect.bottom + 4,
-                              right: window.innerWidth - rect.right
-                            });
-                            setOpenActionMenu(openActionMenu === story.storyId ? null : story.storyId);
-                          }}
-                        >
-                          <FiMoreVertical className="w-4 h-4" />
-                        </button>
-                        {openActionMenu === story.storyId && menuPosition && (
-                          <div 
-                            className="fixed z-[9999] bg-base-100 border border-base-300 rounded-lg shadow-xl min-w-48"
-                            style={{
-                              top: `${menuPosition.top}px`,
-                              right: `${menuPosition.right}px`
-                            }}
-                          >
-                            <div className="p-2 space-y-1">
-                              {story.status === 'published' && (<Link
-                                  href={`/${locale}/stories/${story.storyId}`}
-                                  className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-base-200 rounded-md"
-                                  onClick={() => setOpenActionMenu(null)}
-                                >
-                                  <FiBook className="w-4 h-4" />
-                                  {tCommonActions('read')}
-                                </Link>
-                              )}
-                              
-                              {story.status === 'published' ? (
-                                <button
-                                  className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-base-200 rounded-md w-full text-left"
-                                  onClick={() => {
-                                    handleShare(story);
-                                    setOpenActionMenu(null);
-                                    setMenuPosition(null);
-                                  }}
-                                >
-                                  <FiShare2 className="w-4 h-4" />
-                                  {tMyStoriesPage('actions.share')}
-                                </button>
-                              ) : (
-                                <div className="flex items-center gap-2 px-3 py-2 text-sm text-base-content/50 rounded-md">
-                                  <FiShare2 className="w-4 h-4" />
-                                  {tMyStoriesPage('actions.share')}
-                                </div>
-                              )}
-                              
-                              {story.status === 'published' ? (
-                                <button
-                                  className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-base-200 rounded-md w-full text-left"
-                                  onClick={() => {
-                                    handlePrint(story);
-                                    setOpenActionMenu(null);
-                                    setMenuPosition(null);
-                                  }}
-                                >
-                                  <FiPrinter className="w-4 h-4" />
-                                  {tMyStoriesPage('actions.print')}
-                                </button>
-                              ) : (
-                                <div className="flex items-center gap-2 px-3 py-2 text-sm text-base-content/50 rounded-md">
-                                  <FiPrinter className="w-4 h-4" />
-                                  {tMyStoriesPage('actions.print')}
-                                </div>
-                              )}
-                              
-                              {story.status === 'writing' ? (
-                                <div className="flex items-center gap-2 px-3 py-2 text-sm text-base-content/50 rounded-md">
-                                  <FiEdit3 className="w-4 h-4" />
-                                  {tMyStoriesPage('actions.edit')}
-                                </div>
-                              ) : story.status === 'draft' ? (
-                                <Link
-                                  href={`/${locale}/tell-your-story/step-3?edit=${story.storyId}`}
-                                  className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-base-200 rounded-md"
-                                  onClick={() => {
-                                    setOpenActionMenu(null);
-                                    setMenuPosition(null);
-                                  }}
-                                >
-                                  <FiEdit3 className="w-4 h-4" />
-                                  {tMyStoriesPage('actions.edit')}
-                                </Link>
-                              ) : (
-                                <Link
-                                  href={`/${locale}/stories/edit/${story.storyId}`}
-                                  className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-base-200 rounded-md"
-                                  onClick={() => {
-                                    setOpenActionMenu(null);
-                                    setMenuPosition(null);
-                                  }}
-                                >
-                                  <FiEdit3 className="w-4 h-4" />
-                                  {tMyStoriesPage('actions.edit')}
-                                </Link>
-                              )}
-                              
-                              <div className="border-t border-base-300 my-1"></div>
-                              <button
-                                className={`flex items-center gap-2 px-3 py-2 text-sm rounded-md w-full text-left ${story.status !== 'published' ? 'opacity-50 cursor-not-allowed' : 'hover:bg-base-200'}`}
-                                onClick={() => {
-                                  if (story.status === 'published') {
-                                    handleDuplicate(story);
-                                  }
-                                  setOpenActionMenu(null);
-                                  setMenuPosition(null);
-                                }}
-                                disabled={story.status !== 'published'}
-                              >
-                                <FiCopy className="w-4 h-4" />
-                                {tMyStoriesPage('actions.duplicate')}
-                              </button>
-                              
-                              <button
-                                className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-error hover:text-error-content rounded-md w-full text-left text-error"
-                                onClick={() => {
-                                  handleDeleteClick(story);
-                                  setOpenActionMenu(null);
-                                  setMenuPosition(null);
-                                }}
-                              >
-                                <FiTrash2 className="w-4 h-4" />
-                                {tMyStoriesPage('actions.delete')}
-                              </button>
-                            </div>
-                          </div>
-                        )}
-                      </div>
-                    </td>
-                  </tr>))}
-              </tbody>
-            </table>
-          </div>
-        </>
+        <div className="overflow-x-auto overflow-y-visible">
+          <table className="table table-zebra w-full">
+            <thead>
+              <tr>
+                <th className="px-2 py-1 md:px-4 md:py-2">
+                  <button
+                    className="btn btn-ghost btn-sm p-0 h-auto font-medium text-left justify-start"
+                    onClick={() => handleSort('createdAt')}
+                  >
+                    {tMyStoriesPage('table.date')}
+                    {getSortIcon('createdAt')}
+                  </button>
+                </th>
+                <th className="px-2 py-1 md:px-4 md:py-2">
+                  <button
+                    className="btn btn-ghost btn-sm p-0 h-auto font-medium text-left justify-start"
+                    onClick={() => handleSort('title')}
+                  >
+                    {tMyStoriesPage('table.title')}
+                    {getSortIcon('title')}
+                  </button>
+                </th>
+                <th className="px-2 py-1 md:px-4 md:py-2">
+                  <button
+                    className="btn btn-ghost btn-sm p-0 h-auto font-medium text-left justify-start"
+                    onClick={() => handleSort('status')}
+                  >
+                    {tMyStoriesPage('table.status.header')}
+                    {getSortIcon('status')}
+                  </button>
+                </th>
+                <th className="text-right px-2 py-1 md:px-4 md:py-2">
+                  {tMyStoriesPage('table.actions')}
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {paginatedStories.map((story) => (
+                <StoryRow
+                  key={story.storyId}
+                  story={story}
+                  isMobile={isMobile}
+                  onDelete={handleDeleteClick}
+                  onShare={handleShare}
+                  onPrint={handlePrint}
+                  onDuplicate={handleDuplicate}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
       )}
 
-      {/* Delete Confirmation Modal */}
       {deleteModalOpen && (
         <div className="modal modal-open">
           <div className="modal-box">
             <h3 className="font-bold text-lg">{tMyStoriesPage('deleteConfirm.title')}</h3>
             <p className="py-4">{tMyStoriesPage('deleteConfirm.message')}</p>
             <div className="modal-action">
-              <button
-                className="btn btn-ghost"
-                onClick={() => setDeleteModalOpen(false)}
-              >
+              <button className="btn btn-ghost" onClick={() => setDeleteModalOpen(false)}>
                 {tMyStoriesPage('deleteConfirm.cancel')}
               </button>
-              <button
-                className="btn btn-error"
-                onClick={handleDeleteConfirm}
-              >
+              <button className="btn btn-error" onClick={handleDeleteConfirm}>
                 {tMyStoriesPage('deleteConfirm.confirm')}
               </button>
             </div>
           </div>
         </div>
-  )}
+      )}
 
-  {/* Toasts */}
-  <ToastContainer toasts={toasts} onRemove={removeToast} />
+      <ToastContainer toasts={toasts} onRemove={removeToast} />
 
-  {/* Share Modal */}
       {storyToShare && storyToShare.storyId && (
         <ShareModal
           isOpen={shareModalOpen}
@@ -657,29 +217,27 @@ export default function MyStoriesTable() {
           storyTitle={storyToShare.title}
           isPublic={storyToShare.isPublic}
           slug={storyToShare.slug}
-          onShareSuccess={(shareData) => {
-            console.log('Share successful:', shareData);
-            // Refresh stories to get updated isPublic status
-            const fetchStories = async () => {
+          onShareSuccess={() => {
+            const refresh = async () => {
               try {
                 const response = await fetch('/api/my-stories');
                 if (response.ok) {
                   const data = await response.json();
                   setStories(data.stories);
-                  
-                  // Update storyToShare if it exists to keep it in sync
                   if (storyToShare) {
-                    const updatedStory = data.stories.find((s: Story) => s.storyId === storyToShare.storyId);
-                    if (updatedStory) {
-                      setStoryToShare(updatedStory);
+                    const updated = data.stories.find(
+                      (s: Story) => s.storyId === storyToShare.storyId,
+                    );
+                    if (updated) {
+                      setStoryToShare(updated);
                     }
                   }
                 }
-              } catch (error) {
-                console.error('Error refreshing stories:', error);
+              } catch (err) {
+                console.error('Error refreshing stories:', err);
               }
             };
-            fetchStories();
+            refresh();
           }}
         />
       )}

--- a/src/components/my-stories/StoryRow.tsx
+++ b/src/components/my-stories/StoryRow.tsx
@@ -1,0 +1,379 @@
+'use client';
+
+import { useState, useEffect, useMemo } from 'react';
+import Link from 'next/link';
+import { useTranslations } from 'next-intl';
+import { useLocale } from 'next-intl';
+import {
+  FiEdit3,
+  FiTrash2,
+  FiShare2,
+  FiBook,
+  FiPrinter,
+  FiMoreVertical,
+  FiCopy,
+} from 'react-icons/fi';
+import { Story } from '@/types/story';
+
+interface StoryRowProps {
+  story: Story;
+  isMobile: boolean;
+  onDelete: (story: Story) => void;
+  onShare: (story: Story) => void;
+  onPrint: (story: Story) => void;
+  onDuplicate: (story: Story) => void;
+}
+
+export default function StoryRow({
+  story,
+  isMobile,
+  onDelete,
+  onShare,
+  onPrint,
+  onDuplicate,
+}: StoryRowProps) {
+  const tMyStoriesPage = useTranslations('MyStoriesPage');
+  const tCommonShare = useTranslations('Share');
+  const tCommonActions = useTranslations('Actions');
+  const locale = useLocale();
+
+  const [openMenu, setOpenMenu] = useState(false);
+  const [menuPosition, setMenuPosition] = useState<{ top: number; right: number } | null>(null);
+
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      const target = event.target as Element;
+      if (
+        openMenu &&
+        !target.closest(`[data-story-menu="${story.storyId}"]`) &&
+        !target.closest('.fixed')
+      ) {
+        setOpenMenu(false);
+        setMenuPosition(null);
+      }
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [openMenu, story.storyId]);
+
+  const desktopDateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        day: '2-digit',
+        month: '2-digit',
+        year: '2-digit',
+      }),
+    [locale],
+  );
+
+  const mobileDateFormatter = useMemo(
+    () =>
+      new Intl.DateTimeFormat(locale, {
+        day: '2-digit',
+        month: '2-digit',
+      }),
+    [locale],
+  );
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    if (isNaN(date.getTime())) return '-';
+    return isMobile ? mobileDateFormatter.format(date) : desktopDateFormatter.format(date);
+  };
+
+  const getStatusBadgeClass = (status: string) => {
+    switch (status) {
+      case 'draft':
+        return 'badge badge-secondary';
+      case 'writing':
+        return 'badge badge-warning';
+      case 'published':
+        return 'badge badge-success';
+      default:
+        return 'badge badge-ghost';
+    }
+  };
+
+  const getGenerationStatusInfo = (s: Story) => {
+    if (!s.storyGenerationStatus) return null;
+    const statusMap = {
+      queued: { text: tMyStoriesPage('table.status.queued'), class: 'badge-info', icon: '⏳' },
+      running: { text: tMyStoriesPage('table.status.running'), class: 'badge-warning', icon: '🔄' },
+      completed: { text: tMyStoriesPage('table.status.completed'), class: 'badge-success', icon: '✅' },
+      failed: { text: tMyStoriesPage('table.status.failed'), class: 'badge-error', icon: '❌' },
+      cancelled: { text: tMyStoriesPage('table.status.cancelled'), class: 'badge-neutral', icon: '⏹️' },
+    } as const;
+    const info = statusMap[s.storyGenerationStatus];
+    return { ...info, percentage: s.storyGenerationCompletedPercentage || 0 };
+  };
+
+  return (
+    <tr>
+      <td className="px-2 py-1 md:px-4 md:py-2">{formatDate(story.createdAt)}</td>
+      <td className="font-medium px-2 py-1 md:px-4 md:py-2">
+        {story.status === 'published' ? (
+          <Link
+            href={`/${locale}/stories/${story.storyId}`}
+            className="text-primary hover:text-primary-focus hover:underline cursor-pointer"
+          >
+            {story.title}
+          </Link>
+        ) : (
+          <span>{story.title}</span>
+        )}
+      </td>
+      <td className="px-2 py-1 md:px-4 md:py-2 whitespace-nowrap">
+        <div className="space-y-1">
+          <span className={`${getStatusBadgeClass(story.status)} badge-sm text-xs whitespace-nowrap`}>
+            {tMyStoriesPage(`status.${story.status}`)}
+          </span>
+          {(() => {
+            const genStatus = getGenerationStatusInfo(story);
+            if (genStatus && story.status === 'writing') {
+              return (
+                <div className="flex flex-col space-y-1">
+                  <span className={`badge badge-xs ${genStatus.class} whitespace-nowrap`}>
+                    {genStatus.icon} {genStatus.text}
+                  </span>
+                  {genStatus.percentage > 0 && genStatus.text === 'Generating' && (
+                    <div className="w-full">
+                      <progress
+                        className="progress progress-primary w-full h-2"
+                        value={genStatus.percentage}
+                        max="100"
+                      ></progress>
+                      <span className="text-xs text-gray-500">{genStatus.percentage}%</span>
+                    </div>
+                  )}
+                </div>
+              );
+            }
+            return null;
+          })()}
+        </div>
+      </td>
+      <td className="pl-2 pr-1 py-1 md:px-4 md:py-2">
+        <div className="hidden md:flex justify-end gap-0.5">
+          <button
+            className={`btn btn-ghost btn-sm ${story.status !== 'published' ? 'btn-disabled' : ''}`}
+            onClick={() => story.status === 'published' && onDuplicate(story)}
+            title={tMyStoriesPage('actions.duplicate')}
+            disabled={story.status !== 'published'}
+          >
+            <FiCopy className="w-4 h-4" />
+          </button>
+          {story.status === 'published' && (
+            <Link
+              href={`/${locale}/stories/${story.storyId}`}
+              className="btn btn-ghost btn-sm text-primary hover:bg-primary hover:text-primary-content"
+              title="Read Story"
+            >
+              <FiBook className="w-4 h-4" />
+            </Link>
+          )}
+          {story.status === 'writing' ? (
+            <button
+              className="btn btn-ghost btn-sm btn-disabled"
+              disabled
+              title={tCommonShare('tooltips.cannotShareWriting')}
+            >
+              <FiShare2 className="w-4 h-4" />
+            </button>
+          ) : story.status === 'draft' ? (
+            <button
+              className="btn btn-ghost btn-sm btn-disabled"
+              disabled
+              title={tCommonShare('tooltips.cannotShareDraft')}
+            >
+              <FiShare2 className="w-4 h-4" />
+            </button>
+          ) : (
+            <button
+              className="btn btn-ghost btn-sm"
+              onClick={() => onShare(story)}
+              title={tMyStoriesPage('actions.share')}
+            >
+              <FiShare2 className="w-4 h-4" />
+            </button>
+          )}
+          {story.status === 'published' ? (
+            <button
+              className="btn btn-ghost btn-sm"
+              onClick={() => onPrint(story)}
+              title={tMyStoriesPage('actions.print')}
+            >
+              <FiPrinter className="w-4 h-4" />
+            </button>
+          ) : (
+            <button
+              className="btn btn-ghost btn-sm btn-disabled"
+              disabled
+              title={tMyStoriesPage('actions.printNotAvailable')}
+            >
+              <FiPrinter className="w-4 h-4" />
+            </button>
+          )}
+          {story.status === 'writing' ? (
+            <button
+              className="btn btn-ghost btn-sm btn-disabled"
+              disabled
+              title="Cannot edit story while it's being written"
+            >
+              <FiEdit3 className="w-4 h-4" />
+            </button>
+          ) : story.status === 'draft' ? (
+            <Link
+              href={`/${locale}/tell-your-story/step-3?edit=${story.storyId}`}
+              className="btn btn-ghost btn-sm"
+              title={tMyStoriesPage('actions.edit')}
+            >
+              <FiEdit3 className="w-4 h-4" />
+            </Link>
+          ) : (
+            <Link
+              href={`/${locale}/stories/edit/${story.storyId}`}
+              className="btn btn-ghost btn-sm"
+              title={tMyStoriesPage('actions.edit')}
+            >
+              <FiEdit3 className="w-4 h-4" />
+            </Link>
+          )}
+          <button
+            className="btn btn-ghost btn-sm text-error hover:bg-error hover:text-error-content"
+            onClick={() => onDelete(story)}
+            title={tMyStoriesPage('actions.delete')}
+          >
+            <FiTrash2 className="w-4 h-4" />
+          </button>
+        </div>
+        <div className="md:hidden relative">
+          <button
+            className="btn btn-ghost btn-sm"
+            data-story-menu={story.storyId}
+            onClick={(e) => {
+              const rect = e.currentTarget.getBoundingClientRect();
+              setMenuPosition({
+                top: rect.bottom + 4,
+                right: window.innerWidth - rect.right,
+              });
+              setOpenMenu((prev) => !prev);
+            }}
+          >
+            <FiMoreVertical className="w-4 h-4" />
+          </button>
+          {openMenu && menuPosition && (
+            <div
+              className="fixed z-[9999] bg-base-100 border border-base-300 rounded-lg shadow-xl min-w-48"
+              style={{ top: `${menuPosition.top}px`, right: `${menuPosition.right}px` }}
+            >
+              <div className="p-2 space-y-1">
+                {story.status === 'published' && (
+                  <Link
+                    href={`/${locale}/stories/${story.storyId}`}
+                    className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-base-200 rounded-md"
+                    onClick={() => setOpenMenu(false)}
+                  >
+                    <FiBook className="w-4 h-4" />
+                    {tCommonActions('read')}
+                  </Link>
+                )}
+                {story.status === 'published' ? (
+                  <button
+                    className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-base-200 rounded-md w-full text-left"
+                    onClick={() => {
+                      onShare(story);
+                      setOpenMenu(false);
+                      setMenuPosition(null);
+                    }}
+                  >
+                    <FiShare2 className="w-4 h-4" />
+                    {tMyStoriesPage('actions.share')}
+                  </button>
+                ) : (
+                  <div className="flex items-center gap-2 px-3 py-2 text-sm text-base-content/50 rounded-md">
+                    <FiShare2 className="w-4 h-4" />
+                    {tMyStoriesPage('actions.share')}
+                  </div>
+                )}
+                {story.status === 'published' ? (
+                  <button
+                    className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-base-200 rounded-md w-full text-left"
+                    onClick={() => {
+                      onPrint(story);
+                      setOpenMenu(false);
+                      setMenuPosition(null);
+                    }}
+                  >
+                    <FiPrinter className="w-4 h-4" />
+                    {tMyStoriesPage('actions.print')}
+                  </button>
+                ) : (
+                  <div className="flex items-center gap-2 px-3 py-2 text-sm text-base-content/50 rounded-md">
+                    <FiPrinter className="w-4 h-4" />
+                    {tMyStoriesPage('actions.print')}
+                  </div>
+                )}
+                {story.status === 'writing' ? (
+                  <div className="flex items-center gap-2 px-3 py-2 text-sm text-base-content/50 rounded-md">
+                    <FiEdit3 className="w-4 h-4" />
+                    {tMyStoriesPage('actions.edit')}
+                  </div>
+                ) : story.status === 'draft' ? (
+                  <Link
+                    href={`/${locale}/tell-your-story/step-3?edit=${story.storyId}`}
+                    className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-base-200 rounded-md"
+                    onClick={() => {
+                      setOpenMenu(false);
+                      setMenuPosition(null);
+                    }}
+                  >
+                    <FiEdit3 className="w-4 h-4" />
+                    {tMyStoriesPage('actions.edit')}
+                  </Link>
+                ) : (
+                  <Link
+                    href={`/${locale}/stories/edit/${story.storyId}`}
+                    className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-base-200 rounded-md"
+                    onClick={() => {
+                      setOpenMenu(false);
+                      setMenuPosition(null);
+                    }}
+                  >
+                    <FiEdit3 className="w-4 h-4" />
+                    {tMyStoriesPage('actions.edit')}
+                  </Link>
+                )}
+                <div className="border-t border-base-300 my-1"></div>
+                <button
+                  className={`flex items-center gap-2 px-3 py-2 text-sm rounded-md w-full text-left ${story.status !== 'published' ? 'opacity-50 cursor-not-allowed' : 'hover:bg-base-200'}`}
+                  onClick={() => {
+                    if (story.status === 'published') {
+                      onDuplicate(story);
+                    }
+                    setOpenMenu(false);
+                    setMenuPosition(null);
+                  }}
+                  disabled={story.status !== 'published'}
+                >
+                  <FiCopy className="w-4 h-4" />
+                  {tMyStoriesPage('actions.duplicate')}
+                </button>
+                <button
+                  className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-error hover:text-error-content rounded-md w-full text-left text-error"
+                  onClick={() => {
+                    onDelete(story);
+                    setOpenMenu(false);
+                    setMenuPosition(null);
+                  }}
+                >
+                  <FiTrash2 className="w-4 h-4" />
+                  {tMyStoriesPage('actions.delete')}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </td>
+    </tr>
+  );
+}

--- a/src/hooks/useStoriesTable.ts
+++ b/src/hooks/useStoriesTable.ts
@@ -1,0 +1,92 @@
+'use client';
+
+import { useState, useEffect, useMemo } from 'react';
+import { Story, SortField, SortDirection } from '@/types/story';
+
+export function useStoriesTable(pageSize = Infinity) {
+  const [stories, setStories] = useState<Story[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [sortField, setSortField] = useState<SortField>('createdAt');
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+  const [currentPage, setCurrentPage] = useState(1);
+
+  const fetchStories = async () => {
+    try {
+      const response = await fetch('/api/my-stories');
+      if (response.ok) {
+        const data = await response.json();
+        setStories(data.stories);
+      }
+    } catch (err) {
+      console.error('Error fetching stories:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchStories();
+  }, []);
+
+  const handleSort = (field: SortField) => {
+    if (sortField === field) {
+      setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc');
+    } else {
+      setSortField(field);
+      setSortDirection('asc');
+    }
+    setCurrentPage(1);
+  };
+
+  const sortedStories = useMemo(() => {
+    const sorted = [...stories];
+    sorted.sort((a, b) => {
+      let aValue: string | number;
+      let bValue: string | number;
+      switch (sortField) {
+        case 'title':
+          aValue = a.title.toLowerCase();
+          bValue = b.title.toLowerCase();
+          break;
+        case 'createdAt':
+          aValue = new Date(a.createdAt).getTime();
+          bValue = new Date(b.createdAt).getTime();
+          break;
+        case 'updatedAt':
+          aValue = new Date(a.updatedAt).getTime();
+          bValue = new Date(b.updatedAt).getTime();
+          break;
+        case 'status':
+          aValue = a.status;
+          bValue = b.status;
+          break;
+        default:
+          return 0;
+      }
+      if (aValue < bValue) return sortDirection === 'asc' ? -1 : 1;
+      if (aValue > bValue) return sortDirection === 'asc' ? 1 : -1;
+      return 0;
+    });
+    return sorted;
+  }, [stories, sortField, sortDirection]);
+
+  const pageCount = Math.ceil(sortedStories.length / pageSize);
+  const paginatedStories = useMemo(() => {
+    const start = (currentPage - 1) * pageSize;
+    return sortedStories.slice(start, start + pageSize);
+  }, [sortedStories, currentPage, pageSize]);
+
+  return {
+    stories,
+    setStories,
+    loading,
+    fetchStories,
+    sortField,
+    sortDirection,
+    handleSort,
+    paginatedStories,
+    pageCount,
+    currentPage,
+    setCurrentPage,
+  };
+}

--- a/src/types/story.ts
+++ b/src/types/story.ts
@@ -1,0 +1,14 @@
+export interface Story {
+  storyId: string;
+  title: string;
+  status: 'draft' | 'writing' | 'published';
+  storyGenerationStatus?: 'queued' | 'running' | 'failed' | 'completed' | 'cancelled' | null;
+  storyGenerationCompletedPercentage?: number;
+  isPublic?: boolean;
+  slug?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export type SortField = 'title' | 'createdAt' | 'updatedAt' | 'status';
+export type SortDirection = 'asc' | 'desc';


### PR DESCRIPTION
## Summary
- centralize story table state and sorting in new `useStoriesTable` hook
- move story row rendering and actions to `StoryRow` component
- simplify `MyStoriesTable` to compose the hook and row component

## Testing
- `npm install` (fails: network connectivity error)
- `npm run format:fix` (fails: prettier not found)
- `npm run lint` (fails: next not found)
- `npm run typecheck` (fails: tsc not found)
- `npm test` (fails: cross-env not found)


------
https://chatgpt.com/codex/tasks/task_e_68bff6e2d28c8328a87bf58a5ac1bf71