### PR TITLE
feat(utils): centralize date formatting

### DIFF
--- a/src/app/[locale]/blog/page.tsx
+++ b/src/app/[locale]/blog/page.tsx
@@ -1,14 +1,19 @@
-import { Metadata } from 'next';
-import { notFound } from 'next/navigation';
-import { setRequestLocale, getTranslations } from 'next-intl/server';
-import Link from 'next/link';
-import Image from 'next/image';
-import { FiCalendar, FiClock } from 'react-icons/fi';
-import { blogService, BlogLocale, BLOG_SUPPORTED_LOCALES } from '@/db/services/blog';
-import InlineMarkdown from '@/lib/blog/InlineMarkdown';
-import { routing } from '@/i18n/routing';
-import { calculateReadingTimeFromMdx } from '@/lib/blog/readingTime';
-import { generateHreflangLinks } from '@/lib/hreflang';
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { setRequestLocale, getTranslations } from "next-intl/server";
+import Link from "next/link";
+import Image from "next/image";
+import { FiCalendar, FiClock } from "react-icons/fi";
+import {
+  blogService,
+  BlogLocale,
+  BLOG_SUPPORTED_LOCALES,
+} from "@/db/services/blog";
+import InlineMarkdown from "@/lib/blog/InlineMarkdown";
+import { routing } from "@/i18n/routing";
+import { calculateReadingTimeFromMdx } from "@/lib/blog/readingTime";
+import { generateHreflangLinks } from "@/lib/hreflang";
+import { formatDate } from "@/utils/date";
 
 interface BlogListPageProps {
   params: Promise<{
@@ -20,47 +25,42 @@ interface BlogListPageProps {
 }
 
 export async function generateMetadata({
-  params
+  params,
 }: {
   params: Promise<{ locale: string }>;
 }): Promise<Metadata> {
   const { locale } = await params;
-  const tBlogMetadata = await getTranslations({ locale, namespace: 'Blog.metadata' });
-  const baseUrl = 'https://mythoria.pt';
+  const tBlogMetadata = await getTranslations({
+    locale,
+    namespace: "Blog.metadata",
+  });
+  const baseUrl = "https://mythoria.pt";
   const hreflangLinks = generateHreflangLinks(locale, `/${locale}/blog`);
 
   return {
-    title: tBlogMetadata('listTitle'),
-    description: tBlogMetadata('listDescription'),
-    robots: 'index,follow,max-snippet:-1,max-image-preview:large',
+    title: tBlogMetadata("listTitle"),
+    description: tBlogMetadata("listDescription"),
+    robots: "index,follow,max-snippet:-1,max-image-preview:large",
     alternates: {
       canonical: `${baseUrl}/${locale}/blog/`,
       languages: hreflangLinks,
     },
     openGraph: {
-      title: tBlogMetadata('listTitle'),
-      description: tBlogMetadata('listDescription'),
-      type: 'website',
+      title: tBlogMetadata("listTitle"),
+      description: tBlogMetadata("listDescription"),
+      type: "website",
       url: `${baseUrl}/${locale}/blog/`,
     },
     twitter: {
-      card: 'summary_large_image',
-      title: tBlogMetadata('listTitle'),
-      description: tBlogMetadata('listDescription'),
+      card: "summary_large_image",
+      title: tBlogMetadata("listTitle"),
+      description: tBlogMetadata("listDescription"),
     },
   };
 }
 
 export function generateStaticParams() {
   return routing.locales.map((locale) => ({ locale }));
-}
-
-function formatDate(date: Date, locale: string): string {
-  return new Intl.DateTimeFormat(locale, {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  }).format(date);
 }
 
 // Note: use calculateReadingTimeFromMdx from '@/lib/blog/readingTime'
@@ -71,145 +71,170 @@ export default async function BlogListPage({
 }: BlogListPageProps) {
   const { locale } = await params;
   const { page } = await searchParams;
-  
+
   // Validate locale
   if (!routing.locales.includes(locale as (typeof routing.locales)[number])) {
     notFound();
   }
-  
+
   setRequestLocale(locale);
-  
+
   // Check if locale is supported by blog
   if (!BLOG_SUPPORTED_LOCALES.includes(locale as BlogLocale)) {
     notFound();
   }
-  
-  const t = await getTranslations('Blog.list');
-  const currentPage = parseInt(page || '1', 10);
+
+  const t = await getTranslations("Blog.list");
+  const currentPage = parseInt(page || "1", 10);
   const postsPerPage = 10;
   const offset = (currentPage - 1) * postsPerPage;
-  
+
   try {
     const posts = await blogService.getPublishedList(locale as BlogLocale, {
       limit: postsPerPage,
       offset,
     });
-    
+
     return (
       <div className="min-h-screen bg-base-100">
         <div className="container mx-auto px-4 py-12">
           {/* Header Section */}
           <header className="text-center mb-8">
-            <h1 className="text-5xl font-bold text-primary">{t('title')}</h1>
-            <p className="text-xl mt-4 text-gray-700">{t('subtitle')}</p>
+            <h1 className="text-5xl font-bold text-primary">{t("title")}</h1>
+            <p className="text-xl mt-4 text-gray-700">{t("subtitle")}</p>
           </header>
 
           {/* Blog Posts */}
           <section className="max-w-6xl mx-auto px-4 pt-8 pb-8">
-          {posts.length === 0 ? (
-            <div className="text-center py-16">
-              <div className="mb-8">
-                <div className="text-6xl mb-4">📜</div>
-                <h2 className="text-2xl font-bold mb-4">{t('noPostsFound')}</h2>
-                <p className="text-base-content/70 max-w-md mx-auto">
-                  {t('noPostsFoundDescription')}
-                </p>
+            {posts.length === 0 ? (
+              <div className="text-center py-16">
+                <div className="mb-8">
+                  <div className="text-6xl mb-4">📜</div>
+                  <h2 className="text-2xl font-bold mb-4">
+                    {t("noPostsFound")}
+                  </h2>
+                  <p className="text-base-content/70 max-w-md mx-auto">
+                    {t("noPostsFoundDescription")}
+                  </p>
+                </div>
               </div>
-            </div>
-          ) : (
-            <div className="grid gap-8 md:gap-12">
-              {posts.map((post, index) => (
-                <article
-                  key={post.id}
-                  className={`card lg:card-side bg-base-100 shadow-lg hover:shadow-xl transition-all duration-300 border border-base-300 ${
-                    index % 2 === 1 ? 'lg:flex-row-reverse' : ''
-                  }`}
-                >
-                  {/* Post Image */}
-                  <div className="lg:w-2/5">
-                    <figure className="h-64 lg:h-full">
-                      <Image
-                        src={post.heroImageUrl || '/placeholder-story-image.jpg'}
-                        alt={post.title}
-                        width={600}
-                        height={400}
-                        className="w-full h-full object-cover"
-                        unoptimized={post.heroImageUrl?.startsWith('http')}
-                      />
-                    </figure>
-                  </div>
-                  
-                  {/* Post Content */}
-                  <div className="lg:w-3/5 card-body p-8">
-                    <div className="flex flex-wrap items-center gap-4 text-sm text-base-content/60 mb-4">
-                      <div className="flex items-center gap-2">
-                        <FiCalendar className="w-4 h-4" />
-                        <span>
-                          {t('publishedOn')} {formatDate(post.publishedAt!, locale)}
-                        </span>
-                      </div>
-                      <div className="flex items-center gap-2">
-                        <FiClock className="w-4 h-4" />
-                        <span>{calculateReadingTimeFromMdx(post.contentMdx ?? post.summary)} {t('readingTime', { ns: 'BlogPost' })}</span>
-                      </div>
+            ) : (
+              <div className="grid gap-8 md:gap-12">
+                {posts.map((post, index) => (
+                  <article
+                    key={post.id}
+                    className={`card lg:card-side bg-base-100 shadow-lg hover:shadow-xl transition-all duration-300 border border-base-300 ${
+                      index % 2 === 1 ? "lg:flex-row-reverse" : ""
+                    }`}
+                  >
+                    {/* Post Image */}
+                    <div className="lg:w-2/5">
+                      <figure className="h-64 lg:h-full">
+                        <Image
+                          src={
+                            post.heroImageUrl || "/placeholder-story-image.jpg"
+                          }
+                          alt={post.title}
+                          width={600}
+                          height={400}
+                          className="w-full h-full object-cover"
+                          unoptimized={post.heroImageUrl?.startsWith("http")}
+                        />
+                      </figure>
                     </div>
-                    
-                    <h2 className="card-title text-2xl md:text-3xl mb-4 line-clamp-2">
-                      <Link 
-                        href={`/${locale}/blog/${post.slug}`}
-                        className="hover:text-primary transition-colors"
-                      >
-                        {post.title}
-                      </Link>
-                    </h2>
-                    
-                    <InlineMarkdown
-                      text={post.summary}
-                      className="text-base-content/80 leading-relaxed mb-6 line-clamp-3"
-                    />
-                    
-                    <div className="card-actions justify-end">
-                      <Link
-                        href={`/${locale}/blog/${post.slug}`}
-                        className="btn btn-primary btn-outline hover:btn-primary"
-                      >
-                        {t('readMore')}
-                        <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4 ml-2" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-                        </svg>
-                      </Link>
-                    </div>
-                  </div>
-                </article>
-              ))}
-            </div>
-          )}
-          
-          {/* Pagination */}
-          {posts.length === postsPerPage && (
-            <div className="text-center mt-16">
-              <Link
-                href={`/${locale}/blog?page=${currentPage + 1}`}
-                className="btn btn-primary btn-lg"
-              >
-                {t('loadMore')}
-              </Link>
-            </div>
-          )}
-        </section>
 
+                    {/* Post Content */}
+                    <div className="lg:w-3/5 card-body p-8">
+                      <div className="flex flex-wrap items-center gap-4 text-sm text-base-content/60 mb-4">
+                        <div className="flex items-center gap-2">
+                          <FiCalendar className="w-4 h-4" />
+                          <span>
+                            {t("publishedOn")}{" "}
+                            {formatDate(post.publishedAt!, {
+                              locale,
+                              year: "numeric",
+                              month: "long",
+                              day: "numeric",
+                            })}
+                          </span>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <FiClock className="w-4 h-4" />
+                          <span>
+                            {calculateReadingTimeFromMdx(
+                              post.contentMdx ?? post.summary,
+                            )}{" "}
+                            {t("readingTime", { ns: "BlogPost" })}
+                          </span>
+                        </div>
+                      </div>
+
+                      <h2 className="card-title text-2xl md:text-3xl mb-4 line-clamp-2">
+                        <Link
+                          href={`/${locale}/blog/${post.slug}`}
+                          className="hover:text-primary transition-colors"
+                        >
+                          {post.title}
+                        </Link>
+                      </h2>
+
+                      <InlineMarkdown
+                        text={post.summary}
+                        className="text-base-content/80 leading-relaxed mb-6 line-clamp-3"
+                      />
+
+                      <div className="card-actions justify-end">
+                        <Link
+                          href={`/${locale}/blog/${post.slug}`}
+                          className="btn btn-primary btn-outline hover:btn-primary"
+                        >
+                          {t("readMore")}
+                          <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            className="h-4 w-4 ml-2"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                          >
+                            <path
+                              strokeLinecap="round"
+                              strokeLinejoin="round"
+                              strokeWidth={2}
+                              d="M9 5l7 7-7 7"
+                            />
+                          </svg>
+                        </Link>
+                      </div>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            )}
+
+            {/* Pagination */}
+            {posts.length === postsPerPage && (
+              <div className="text-center mt-16">
+                <Link
+                  href={`/${locale}/blog?page=${currentPage + 1}`}
+                  className="btn btn-primary btn-lg"
+                >
+                  {t("loadMore")}
+                </Link>
+              </div>
+            )}
+          </section>
         </div>
       </div>
     );
   } catch (error) {
-    console.error('Failed to load blog posts:', error);
+    console.error("Failed to load blog posts:", error);
     return (
       <div className="min-h-screen bg-base-100 flex items-center justify-center">
         <div className="text-center">
           <div className="text-6xl mb-4">🔮</div>
-          <h1 className="text-2xl font-bold mb-4">{t('error')}</h1>
+          <h1 className="text-2xl font-bold mb-4">{t("error")}</h1>
           <Link href={`/${locale}/blog`} className="btn btn-primary">
-            {t('tryAgain')}
+            {t("tryAgain")}
           </Link>
         </div>
       </div>

--- a/src/app/[locale]/p/[slug]/page.tsx
+++ b/src/app/[locale]/p/[slug]/page.tsx
@@ -1,11 +1,22 @@
-'use client';
+"use client";
 
-import { useEffect, useState } from 'react';
-import { useParams } from 'next/navigation';
-import { useLocale, useTranslations } from 'next-intl';
-import { FiLoader, FiAlertCircle, FiUser, FiCalendar, FiTag, FiEye, FiPrinter, FiVolume2, FiEdit3 } from 'react-icons/fi';
-import PublicStoryRating from '@/components/PublicStoryRating';
-import StoryReader from '@/components/StoryReader';
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import { useLocale, useTranslations } from "next-intl";
+import {
+  FiLoader,
+  FiAlertCircle,
+  FiUser,
+  FiCalendar,
+  FiTag,
+  FiEye,
+  FiPrinter,
+  FiVolume2,
+  FiEdit3,
+} from "react-icons/fi";
+import PublicStoryRating from "@/components/PublicStoryRating";
+import StoryReader from "@/components/StoryReader";
+import { formatDate } from "@/utils/date";
 
 interface Chapter {
   id: string;
@@ -27,12 +38,14 @@ interface PublicStoryData {
     title: string;
     authorName: string;
     synopsis?: string;
-    audiobookUri?: Array<{
-      chapterTitle: string;
-      audioUri: string;
-      duration: number;
-      imageUri?: string;
-    }> | Record<string, string>;
+    audiobookUri?:
+      | Array<{
+          chapterTitle: string;
+          audioUri: string;
+          duration: number;
+          imageUri?: string;
+        }>
+      | Record<string, string>;
     targetAudience?: string;
     graphicalStyle?: string;
     novelStyle?: string;
@@ -46,49 +59,54 @@ interface PublicStoryData {
     hasAudio?: boolean;
   };
   chapters: Chapter[];
-  accessLevel: 'public';
+  accessLevel: "public";
   error?: string;
 }
 
 export default function PublicStoryPage() {
   const params = useParams();
   const locale = useLocale();
-  const tPublicStoryPage = useTranslations('PublicStoryPage');
-  const tActions = useTranslations('Actions');
-  const tGetInspiredPage = useTranslations('GetInspiredPage');
+  const tPublicStoryPage = useTranslations("PublicStoryPage");
+  const tActions = useTranslations("Actions");
+  const tGetInspiredPage = useTranslations("GetInspiredPage");
   const slug = Array.isArray(params?.slug)
-    ? (params?.slug[0] ?? '')
-    : (params?.slug as string | undefined) ?? '';
-  
+    ? (params?.slug[0] ?? "")
+    : ((params?.slug as string | undefined) ?? "");
+
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<PublicStoryData | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!slug) return;    const fetchPublicStory = async () => {
+    if (!slug) return;
+    const fetchPublicStory = async () => {
       try {
         const response = await fetch(`/api/p/${slug}`);
-        
+
         if (!response.ok) {
           const errorText = await response.text();
-          console.error('[Public Page] Response error:', errorText);
-          throw new Error(`HTTP error! status: ${response.status}, message: ${errorText}`);
+          console.error("[Public Page] Response error:", errorText);
+          throw new Error(
+            `HTTP error! status: ${response.status}, message: ${errorText}`,
+          );
         }
-        
+
         const result = await response.json();
-        console.log('[Public Page] Response data:', result);
+        console.log("[Public Page] Response data:", result);
         if (result.success) {
           // Story data fetched successfully
           setData(result);
-          
         } else {
-          console.error('[Public Page] API returned error:', result.error);
-          setError(result.error || tPublicStoryPage('errors.notFound'));
+          console.error("[Public Page] API returned error:", result.error);
+          setError(result.error || tPublicStoryPage("errors.notFound"));
         }
       } catch (err) {
-        console.error('[Public Page] Error fetching public story:', err);
-        const errorMessage = err instanceof Error ? err.message : 'Unknown error';
-        setError(`${tPublicStoryPage('errors.failedToLoadStory')}: ${errorMessage}`);
+        console.error("[Public Page] Error fetching public story:", err);
+        const errorMessage =
+          err instanceof Error ? err.message : "Unknown error";
+        setError(
+          `${tPublicStoryPage("errors.failedToLoadStory")}: ${errorMessage}`,
+        );
       } finally {
         setLoading(false);
       }
@@ -102,16 +120,21 @@ export default function PublicStoryPage() {
       const story = data.story;
       // Set page title directly with the format "StoryTitle | Mythoria"
       document.title = `${story.title} | Mythoria`;
-      
+
       // Set meta description
-      const metaDescription = document.querySelector('meta[name="description"]');
-      const description = story.synopsis || story.plotDescription || tPublicStoryPage('metadata.defaultDescription', { title: story.title });
+      const metaDescription = document.querySelector(
+        'meta[name="description"]',
+      );
+      const description =
+        story.synopsis ||
+        story.plotDescription ||
+        tPublicStoryPage("metadata.defaultDescription", { title: story.title });
 
       if (metaDescription) {
-        metaDescription.setAttribute('content', description);
+        metaDescription.setAttribute("content", description);
       } else {
-        const meta = document.createElement('meta');
-        meta.name = 'description';
+        const meta = document.createElement("meta");
+        meta.name = "description";
         meta.content = description;
         document.head.appendChild(meta);
       }
@@ -120,39 +143,42 @@ export default function PublicStoryPage() {
       const setMetaTag = (property: string, content: string) => {
         let meta = document.querySelector(`meta[property="${property}"]`);
         if (!meta) {
-          meta = document.createElement('meta');
-          meta.setAttribute('property', property);
+          meta = document.createElement("meta");
+          meta.setAttribute("property", property);
           document.head.appendChild(meta);
         }
-        meta.setAttribute('content', content);
+        meta.setAttribute("content", content);
       };
 
       const baseUrl = window.location.origin;
-      setMetaTag('og:title', `${story.title} | Mythoria`);
-      setMetaTag('og:description', description);
-      setMetaTag('og:type', 'article');
-      setMetaTag('og:url', window.location.href);
-      setMetaTag('og:site_name', 'Mythoria');
-      setMetaTag('og:image', `${baseUrl}/api/og/story/${slug}`);
-      setMetaTag('og:image:width', '1200');
-      setMetaTag('og:image:height', '630');
-      setMetaTag('og:image:alt', tPublicStoryPage('metadata.coverImageAlt', { title: story.title }));
+      setMetaTag("og:title", `${story.title} | Mythoria`);
+      setMetaTag("og:description", description);
+      setMetaTag("og:type", "article");
+      setMetaTag("og:url", window.location.href);
+      setMetaTag("og:site_name", "Mythoria");
+      setMetaTag("og:image", `${baseUrl}/api/og/story/${slug}`);
+      setMetaTag("og:image:width", "1200");
+      setMetaTag("og:image:height", "630");
+      setMetaTag(
+        "og:image:alt",
+        tPublicStoryPage("metadata.coverImageAlt", { title: story.title }),
+      );
 
       // Twitter Card tags
       const setTwitterTag = (name: string, content: string) => {
         let meta = document.querySelector(`meta[name="${name}"]`);
         if (!meta) {
-          meta = document.createElement('meta');
-          meta.setAttribute('name', name);
+          meta = document.createElement("meta");
+          meta.setAttribute("name", name);
           document.head.appendChild(meta);
         }
-        meta.setAttribute('content', content);
+        meta.setAttribute("content", content);
       };
 
-      setTwitterTag('twitter:card', 'summary_large_image');
-      setTwitterTag('twitter:title', `${story.title} | Mythoria`);
-      setTwitterTag('twitter:description', description);
-      setTwitterTag('twitter:image', `${baseUrl}/api/og/story/${slug}`);
+      setTwitterTag("twitter:card", "summary_large_image");
+      setTwitterTag("twitter:title", `${story.title} | Mythoria`);
+      setTwitterTag("twitter:description", description);
+      setTwitterTag("twitter:image", `${baseUrl}/api/og/story/${slug}`);
     }
   }, [data, slug, tPublicStoryPage]);
   if (loading) {
@@ -160,8 +186,12 @@ export default function PublicStoryPage() {
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center space-y-4">
           <FiLoader className="animate-spin text-4xl text-primary mx-auto" />
-          <h2 className="text-xl font-semibold">{tPublicStoryPage('loading.title')}</h2>
-          <p className="text-gray-600">{tPublicStoryPage('loading.subtitle')}</p>
+          <h2 className="text-xl font-semibold">
+            {tPublicStoryPage("loading.title")}
+          </h2>
+          <p className="text-gray-600">
+            {tPublicStoryPage("loading.subtitle")}
+          </p>
         </div>
       </div>
     );
@@ -171,15 +201,16 @@ export default function PublicStoryPage() {
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center space-y-4 max-w-md mx-auto px-4">
           <FiAlertCircle className="text-4xl text-red-500 mx-auto" />
-          <h2 className="text-xl font-semibold text-gray-900">{tPublicStoryPage('errors.notFound')}</h2>
-          <p className="text-gray-600">{error || tPublicStoryPage('errors.notFoundDesc')}</p>
-          
+          <h2 className="text-xl font-semibold text-gray-900">
+            {tPublicStoryPage("errors.notFound")}
+          </h2>
+          <p className="text-gray-600">
+            {error || tPublicStoryPage("errors.notFoundDesc")}
+          </p>
+
           <div className="space-y-2">
-            <a
-              href={`/${locale}`}
-              className="btn btn-primary btn-sm"
-            >
-              {tActions('goToHomepage')}
+            <a href={`/${locale}`} className="btn btn-primary btn-sm">
+              {tActions("goToHomepage")}
             </a>
           </div>
         </div>
@@ -197,8 +228,10 @@ export default function PublicStoryPage() {
           <div className="max-w-4xl mx-auto">
             <div className="flex flex-col gap-4">
               {/* Title */}
-              <h1 className="text-3xl font-bold text-gray-900">{story.title}</h1>
-              
+              <h1 className="text-3xl font-bold text-gray-900">
+                {story.title}
+              </h1>
+
               {/* Actions - Mobile responsive layout */}
               <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
                 {/* Tags and Action Buttons */}
@@ -208,8 +241,12 @@ export default function PublicStoryPage() {
                     className="btn btn-primary btn-sm flex items-center gap-2 text-xs sm:text-sm"
                   >
                     <FiPrinter className="w-3 h-3 sm:w-4 sm:h-4" />
-                    <span className="hidden min-[480px]:inline">{tPublicStoryPage('actions.orderPrint')}</span>
-                    <span className="min-[480px]:hidden">{tPublicStoryPage('actions.print')}</span>
+                    <span className="hidden min-[480px]:inline">
+                      {tPublicStoryPage("actions.orderPrint")}
+                    </span>
+                    <span className="min-[480px]:hidden">
+                      {tPublicStoryPage("actions.print")}
+                    </span>
                   </a>
                   {story.hasAudio && (
                     <a
@@ -217,48 +254,68 @@ export default function PublicStoryPage() {
                       className="btn btn-secondary btn-sm flex items-center gap-2 text-xs sm:text-sm"
                     >
                       <FiVolume2 className="w-3 h-3 sm:w-4 sm:h-4" />
-                      <span className="hidden min-[480px]:inline">{tPublicStoryPage('actions.listen')}</span>
-                      <span className="min-[480px]:hidden">{tPublicStoryPage('actions.listenMobile')}</span>
+                      <span className="hidden min-[480px]:inline">
+                        {tPublicStoryPage("actions.listen")}
+                      </span>
+                      <span className="min-[480px]:hidden">
+                        {tPublicStoryPage("actions.listenMobile")}
+                      </span>
                     </a>
                   )}
                 </div>
               </div>
             </div>
-            
+
             <div className="flex flex-wrap items-center gap-4 text-sm text-gray-600 mt-4">
               <div className="flex items-center gap-1">
                 <FiUser />
-                <span>{tPublicStoryPage('labels.by')} {story.authorName || tPublicStoryPage('labels.unknownAuthor')}</span>
+                <span>
+                  {tPublicStoryPage("labels.by")}{" "}
+                  {story.authorName || tPublicStoryPage("labels.unknownAuthor")}
+                </span>
               </div>
-                <div className="flex items-center gap-1">
+              <div className="flex items-center gap-1">
                 <FiCalendar />
-                <span>{new Date(story.createdAt).toLocaleDateString(locale)}</span>
-              </div>              
+                <span>{formatDate(story.createdAt, { locale })}</span>
+              </div>
               {story.targetAudience && (
                 <div className="flex items-center gap-1">
                   <FiTag />
-                  <span>{tGetInspiredPage(`targetAudience.${story.targetAudience}`) || story.targetAudience.replace('_', ' ')}</span>
+                  <span>
+                    {tGetInspiredPage(
+                      `targetAudience.${story.targetAudience}`,
+                    ) || story.targetAudience.replace("_", " ")}
+                  </span>
                 </div>
               )}
-              
+
               {story.graphicalStyle && (
                 <div className="flex items-center gap-1">
                   <FiEye />
-                  <span>{tGetInspiredPage(`graphicalStyle.${story.graphicalStyle}`) || story.graphicalStyle.replace('_', ' ')}</span>
+                  <span>
+                    {tGetInspiredPage(
+                      `graphicalStyle.${story.graphicalStyle}`,
+                    ) || story.graphicalStyle.replace("_", " ")}
+                  </span>
                 </div>
               )}
-              
+
               {story.novelStyle && (
                 <div className="flex items-center gap-1">
                   <FiTag />
-                  <span>{tGetInspiredPage(`novelStyle.${story.novelStyle}`) || story.novelStyle.replace('_', ' ')}</span>
+                  <span>
+                    {tGetInspiredPage(`novelStyle.${story.novelStyle}`) ||
+                      story.novelStyle.replace("_", " ")}
+                  </span>
                 </div>
               )}
             </div>
-            
+
             {(story.synopsis || story.plotDescription) && (
               <div className="mt-4 p-4 bg-gray-50 rounded-lg">
-                <h3 className="font-bold text-gray-900 mb-2">{tPublicStoryPage('labels.synopsis')}</h3>
+                <h3 className="font-bold text-gray-900 mb-2">
+                  {tPublicStoryPage("labels.synopsis")}
+                </h3>
                 <p className="text-gray-700 leading-relaxed text-sm">
                   {story.synopsis || story.plotDescription}
                 </p>
@@ -267,7 +324,7 @@ export default function PublicStoryPage() {
           </div>
         </div>
       </div>
-      
+
       {/* Story Content */}
       <div className="py-6">
         {data?.chapters && data.chapters.length > 0 ? (
@@ -291,54 +348,56 @@ export default function PublicStoryPage() {
             <div className="max-w-4xl mx-auto">
               <div className="bg-white rounded-lg shadow-sm border p-8 text-center">
                 <FiAlertCircle className="text-4xl text-gray-400 mx-auto mb-4" />
-                <h3 className="text-lg font-medium text-gray-900 mb-2">{tPublicStoryPage('errors.contentNotAvailable')}</h3>
+                <h3 className="text-lg font-medium text-gray-900 mb-2">
+                  {tPublicStoryPage("errors.contentNotAvailable")}
+                </h3>
                 <p className="text-gray-600">
-                  {tPublicStoryPage('errors.contentNotAvailableDesc')}
+                  {tPublicStoryPage("errors.contentNotAvailableDesc")}
                 </p>
               </div>
             </div>
           </div>
         )}
-        
+
         {/* Story Complete CTAs */}
         <div className="container mx-auto px-4 mt-8">
           <div className="max-w-4xl mx-auto">
             <div className="bg-gradient-to-r from-blue-50 to-purple-50 rounded-lg p-6 border border-blue-200 print:hidden">
               <h3 className="text-xl font-bold text-gray-900 mb-3 text-center">
-                {tPublicStoryPage('storyComplete.enjoyedTitle')}
+                {tPublicStoryPage("storyComplete.enjoyedTitle")}
               </h3>
               <p className="text-gray-700 text-center mb-6">
-                {tPublicStoryPage('storyComplete.enjoyedDesc')}
+                {tPublicStoryPage("storyComplete.enjoyedDesc")}
               </p>
-              
+
               <div className="flex flex-col sm:flex-row gap-4 justify-center">
                 <a
                   href={`/${locale}`}
                   className="btn btn-primary flex items-center gap-2"
                 >
                   <FiEdit3 className="w-4 h-4" />
-                  {tPublicStoryPage('actions.createOwnStory')}
+                  {tPublicStoryPage("actions.createOwnStory")}
                 </a>
-                
+
                 <a
                   href={`/${locale}/stories/print/${story.storyId}`}
                   className="btn btn-secondary flex items-center gap-2"
                 >
                   <FiPrinter className="w-4 h-4" />
-                  {tPublicStoryPage('actions.orderPrintedBook')}
+                  {tPublicStoryPage("actions.orderPrintedBook")}
                 </a>
               </div>
             </div>
           </div>
         </div>
-        
+
         {/* Story Rating Section */}
         <div className="container mx-auto px-4 mt-8">
           <div className="max-w-4xl mx-auto">
             <PublicStoryRating
               storyId={story.storyId}
               onRatingSubmitted={(rating) => {
-                console.log('Rating submitted:', rating);
+                console.log("Rating submitted:", rating);
               }}
             />
           </div>
@@ -352,7 +411,7 @@ export default function PublicStoryPage() {
             padding: 0.25rem 0.5rem;
             font-size: 0.75rem;
           }
-          
+
           .badge {
             padding: 0.25rem 0.5rem;
             font-size: 0.75rem;

--- a/src/components/CreditsDisplay.tsx
+++ b/src/components/CreditsDisplay.tsx
@@ -1,9 +1,10 @@
-'use client';
+"use client";
 
-import { useState, useEffect, useRef } from 'react';
-import { useTranslations } from 'next-intl';
-import { useLocale } from 'next-intl';
-import Link from 'next/link';
+import { useState, useEffect, useRef } from "react";
+import { useTranslations } from "next-intl";
+import { useLocale } from "next-intl";
+import Link from "next/link";
+import { formatDate } from "@/utils/date";
 
 interface CreditHistoryEntry {
   id: string;
@@ -20,8 +21,8 @@ interface CreditsDisplayProps {
 }
 
 export default function CreditsDisplay({ credits }: CreditsDisplayProps) {
-  const tCommonCreditsDisplay = useTranslations('CreditsDisplay');
-  const tCommonActions = useTranslations('Actions');
+  const tCommonCreditsDisplay = useTranslations("CreditsDisplay");
+  const tCommonActions = useTranslations("Actions");
   const locale = useLocale();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [creditHistory, setCreditHistory] = useState<CreditHistoryEntry[]>([]);
@@ -38,7 +39,7 @@ export default function CreditsDisplay({ credits }: CreditsDisplayProps) {
     setLoading(true);
 
     try {
-      const response = await fetch('/api/my-credits');
+      const response = await fetch("/api/my-credits");
       if (response.ok) {
         const data = await response.json();
         setCreditHistory(data.creditHistory);
@@ -46,65 +47,50 @@ export default function CreditsDisplay({ credits }: CreditsDisplayProps) {
 
         // Scroll to the end of the table after data loads
         setTimeout(() => {
-          tableEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+          tableEndRef.current?.scrollIntoView({ behavior: "smooth" });
         }, 100);
       }
     } catch (error) {
-      console.error('Error fetching credit history:', error);
+      console.error("Error fetching credit history:", error);
     } finally {
       setLoading(false);
     }
-  };  const formatDate = (dateString: string, isMobile = false) => {
-    const date = new Date(dateString);
-    
-    if (isMobile) {
-      // Mobile format: "Jun 17" (no year, no time)
-      return date.toLocaleDateString(locale, {
-        month: 'short',
-        day: 'numeric'
-      });
-    }
-    
-    // Desktop format: full date with time
-    return date.toLocaleDateString(locale, {
-      year: '2-digit',
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit'
-    });
   };
   const formatEventType = (eventType: string) => {
     const eventTypes: { [key: string]: string } = {
-      'initialCredit': tCommonCreditsDisplay('eventTypes.initialCredit'),
-      'creditPurchase': tCommonCreditsDisplay('eventTypes.creditPurchase'),
-      'eBookGeneration': tCommonCreditsDisplay('eventTypes.eBookGeneration'),
-      'audioBookGeneration': tCommonCreditsDisplay('eventTypes.audioBookGeneration'),
-      'printOrder': tCommonCreditsDisplay('eventTypes.printOrder'),
-      'refund': tCommonCreditsDisplay('eventTypes.refund'),
-      'voucher': tCommonCreditsDisplay('eventTypes.voucher'),
-      'promotion': tCommonCreditsDisplay('eventTypes.promotion')
+      initialCredit: tCommonCreditsDisplay("eventTypes.initialCredit"),
+      creditPurchase: tCommonCreditsDisplay("eventTypes.creditPurchase"),
+      eBookGeneration: tCommonCreditsDisplay("eventTypes.eBookGeneration"),
+      audioBookGeneration: tCommonCreditsDisplay(
+        "eventTypes.audioBookGeneration",
+      ),
+      printOrder: tCommonCreditsDisplay("eventTypes.printOrder"),
+      refund: tCommonCreditsDisplay("eventTypes.refund"),
+      voucher: tCommonCreditsDisplay("eventTypes.voucher"),
+      promotion: tCommonCreditsDisplay("eventTypes.promotion"),
     };
     return eventTypes[eventType] || eventType;
   };
 
   const getAmountColor = (amount: number) => {
-    return amount > 0 ? 'text-green-600' : 'text-red-600';
+    return amount > 0 ? "text-green-600" : "text-red-600";
   };
 
   return (
-    <>      <button
-      className="btn btn-outline btn-primary"
-      onClick={handleOpenModal}
-    >
-      {tCommonCreditsDisplay('button', { credits: currentBalance.toString() })}
-    </button>
-
+    <>
+      {" "}
+      <button className="btn btn-outline btn-primary" onClick={handleOpenModal}>
+        {tCommonCreditsDisplay("button", {
+          credits: currentBalance.toString(),
+        })}
+      </button>
       {/* Credit History Modal */}
       {isModalOpen && (
         <div className="modal modal-open">
           <div className="modal-box max-w-4xl">
-            <h3 className="font-bold text-lg mb-4">{tCommonCreditsDisplay('creditHistory')}</h3>
+            <h3 className="font-bold text-lg mb-4">
+              {tCommonCreditsDisplay("creditHistory")}
+            </h3>
 
             {loading ? (
               <div className="flex justify-center items-center py-8">
@@ -115,25 +101,47 @@ export default function CreditsDisplay({ credits }: CreditsDisplayProps) {
                 <div className="overflow-x-auto max-h-96 overflow-y-auto">
                   <table className="table table-zebra w-full">
                     <thead className="sticky top-0 bg-base-100 z-10">
-                    <tr>
-                      <th>{tCommonCreditsDisplay('headers.date')}</th>
-                      <th>{tCommonCreditsDisplay('headers.eventType')}</th>
-                      <th className="text-right">{tCommonCreditsDisplay('headers.amount')}</th>
-                      <th className="text-right">{tCommonCreditsDisplay('headers.balance')}</th>
-                    </tr>
-                  </thead>
+                      <tr>
+                        <th>{tCommonCreditsDisplay("headers.date")}</th>
+                        <th>{tCommonCreditsDisplay("headers.eventType")}</th>
+                        <th className="text-right">
+                          {tCommonCreditsDisplay("headers.amount")}
+                        </th>
+                        <th className="text-right">
+                          {tCommonCreditsDisplay("headers.balance")}
+                        </th>
+                      </tr>
+                    </thead>
                     <tbody>
                       {creditHistory.map((entry) => (
                         <tr key={entry.id}>
                           <td className="text-sm">
                             {/* Mobile: Short date format */}
-                            <span className="md:hidden">{formatDate(entry.createdAt, true)}</span>
+                            <span className="md:hidden">
+                              {formatDate(entry.createdAt, {
+                                locale,
+                                month: "short",
+                                day: "numeric",
+                              })}
+                            </span>
                             {/* Desktop: Full date format */}
-                            <span className="hidden md:inline">{formatDate(entry.createdAt, false)}</span>
+                            <span className="hidden md:inline">
+                              {formatDate(entry.createdAt, {
+                                locale,
+                                year: "2-digit",
+                                month: "short",
+                                day: "numeric",
+                                hour: "2-digit",
+                                minute: "2-digit",
+                              })}
+                            </span>
                           </td>
                           <td>{formatEventType(entry.creditEventType)}</td>
-                          <td className={`text-right font-mono ${getAmountColor(entry.amount)}`}>
-                            {entry.amount > 0 ? '+' : ''}{entry.amount}
+                          <td
+                            className={`text-right font-mono ${getAmountColor(entry.amount)}`}
+                          >
+                            {entry.amount > 0 ? "+" : ""}
+                            {entry.amount}
                           </td>
                           <td className="text-right font-mono font-semibold">
                             {entry.balanceAfter}
@@ -146,13 +154,20 @@ export default function CreditsDisplay({ credits }: CreditsDisplayProps) {
                 </div>
                 <div className="mt-6 p-4 bg-base-200 rounded-lg">
                   <div className="flex justify-between items-center">
-                    <span className="text-lg font-semibold">{tCommonCreditsDisplay('currentBalance')}</span>
-                    <span className="text-xl font-bold text-primary">{currentBalance} {tCommonCreditsDisplay('credits')}</span>
+                    <span className="text-lg font-semibold">
+                      {tCommonCreditsDisplay("currentBalance")}
+                    </span>
+                    <span className="text-xl font-bold text-primary">
+                      {currentBalance} {tCommonCreditsDisplay("credits")}
+                    </span>
                   </div>
                 </div>
                 <div className="mt-4">
-                  <Link href={`/${locale}/buy-credits`} className="btn btn-primary w-full">
-                    {tCommonCreditsDisplay('addCredits')}
+                  <Link
+                    href={`/${locale}/buy-credits`}
+                    className="btn btn-primary w-full"
+                  >
+                    {tCommonCreditsDisplay("addCredits")}
                   </Link>
                 </div>
               </>
@@ -162,7 +177,7 @@ export default function CreditsDisplay({ credits }: CreditsDisplayProps) {
                 className="btn btn-ghost"
                 onClick={() => setIsModalOpen(false)}
               >
-                {tCommonActions('close')}
+                {tCommonActions("close")}
               </button>
             </div>
           </div>

--- a/src/components/StoryInfoEditor.tsx
+++ b/src/components/StoryInfoEditor.tsx
@@ -1,17 +1,18 @@
-'use client';
+"use client";
 
-import { useState, useEffect } from 'react';
-import Image from 'next/image';
-import { 
-  FiSave, 
-  FiImage, 
+import { useState, useEffect } from "react";
+import Image from "next/image";
+import {
+  FiSave,
+  FiImage,
   FiUser,
   FiBook,
   FiHeart,
-  FiGlobe
-} from 'react-icons/fi';
-import { useTranslations } from 'next-intl';
-import { toAbsoluteImageUrl } from '../utils/image-url';
+  FiGlobe,
+} from "react-icons/fi";
+import { useTranslations } from "next-intl";
+import { formatDate } from "@/utils/date";
+import { toAbsoluteImageUrl } from "../utils/image-url";
 
 interface Story {
   storyId: string;
@@ -45,31 +46,31 @@ export default function StoryInfoEditor({
   isLoading = false,
   onTranslateClick,
 }: StoryInfoEditorProps) {
-  const tStoryInfoEditor = useTranslations('StoryInfoEditor');
-  
+  const tStoryInfoEditor = useTranslations("StoryInfoEditor");
+
   const [formData, setFormData] = useState({
-    title: story.title || '',
-    synopsis: story.synopsis || '',
-    dedicationMessage: story.dedicationMessage || '',
-    customAuthor: story.customAuthor || '',
-    targetAudience: story.targetAudience || '',
+    title: story.title || "",
+    synopsis: story.synopsis || "",
+    dedicationMessage: story.dedicationMessage || "",
+    customAuthor: story.customAuthor || "",
+    targetAudience: story.targetAudience || "",
   });
   const [hasUnsavedChanges, setHasUnsavedChanges] = useState(false);
 
   // Track changes
   useEffect(() => {
-    const hasChanges = 
-      formData.title !== (story.title || '') ||
-      formData.synopsis !== (story.synopsis || '') ||
-      formData.dedicationMessage !== (story.dedicationMessage || '') ||
-      formData.customAuthor !== (story.customAuthor || '') ||
-      formData.targetAudience !== (story.targetAudience || '');
-    
+    const hasChanges =
+      formData.title !== (story.title || "") ||
+      formData.synopsis !== (story.synopsis || "") ||
+      formData.dedicationMessage !== (story.dedicationMessage || "") ||
+      formData.customAuthor !== (story.customAuthor || "") ||
+      formData.targetAudience !== (story.targetAudience || "");
+
     setHasUnsavedChanges(hasChanges);
   }, [formData, story]);
 
   const handleInputChange = (field: string, value: string) => {
-    setFormData(prev => ({
+    setFormData((prev) => ({
       ...prev,
       [field]: value,
     }));
@@ -77,12 +78,12 @@ export default function StoryInfoEditor({
 
   const handleSave = async () => {
     if (!hasUnsavedChanges) return;
-    
+
     try {
       await onSave(formData);
       setHasUnsavedChanges(false);
     } catch (error) {
-      console.error(tStoryInfoEditor('logging.errorSavingStoryInfo'), error);
+      console.error(tStoryInfoEditor("logging.errorSavingStoryInfo"), error);
     }
   };
 
@@ -91,7 +92,7 @@ export default function StoryInfoEditor({
       <div className="flex items-center justify-between">
         <h2 className="text-2xl font-bold flex items-center gap-2">
           <FiBook className="w-6 h-6" />
-          {tStoryInfoEditor('title')}
+          {tStoryInfoEditor("title")}
         </h2>
         <button
           onClick={handleSave}
@@ -103,7 +104,9 @@ export default function StoryInfoEditor({
           ) : (
             <FiSave className="w-4 h-4" />
           )}
-          {isLoading ? tStoryInfoEditor('saving') : tStoryInfoEditor('saveButton')}
+          {isLoading
+            ? tStoryInfoEditor("saving")
+            : tStoryInfoEditor("saveButton")}
         </button>
       </div>
 
@@ -113,27 +116,27 @@ export default function StoryInfoEditor({
           {/* Title */}
           <div className="space-y-2">
             <label className="block text-sm font-medium text-base-content">
-              {tStoryInfoEditor('storyTitle')}
+              {tStoryInfoEditor("storyTitle")}
             </label>
             <input
               type="text"
               value={formData.title}
-              onChange={(e) => handleInputChange('title', e.target.value)}
+              onChange={(e) => handleInputChange("title", e.target.value)}
               className="input input-bordered w-full"
-              placeholder={tStoryInfoEditor('titlePlaceholder')}
+              placeholder={tStoryInfoEditor("titlePlaceholder")}
             />
           </div>
 
           {/* Synopsis */}
           <div className="space-y-2">
             <label className="block text-sm font-medium text-base-content">
-              {tStoryInfoEditor('synopsis')}
+              {tStoryInfoEditor("synopsis")}
             </label>
             <textarea
               value={formData.synopsis}
-              onChange={(e) => handleInputChange('synopsis', e.target.value)}
+              onChange={(e) => handleInputChange("synopsis", e.target.value)}
               className="textarea textarea-bordered w-full h-24"
-              placeholder={tStoryInfoEditor('synopsisPlaceholder')}
+              placeholder={tStoryInfoEditor("synopsisPlaceholder")}
             />
           </div>
 
@@ -141,13 +144,15 @@ export default function StoryInfoEditor({
           <div className="space-y-2">
             <label className="block text-sm font-medium text-base-content flex items-center gap-2">
               <FiHeart className="w-4 h-4" />
-              {tStoryInfoEditor('dedicationMessage')}
+              {tStoryInfoEditor("dedicationMessage")}
             </label>
             <textarea
               value={formData.dedicationMessage}
-              onChange={(e) => handleInputChange('dedicationMessage', e.target.value)}
+              onChange={(e) =>
+                handleInputChange("dedicationMessage", e.target.value)
+              }
               className="textarea textarea-bordered w-full h-20"
-              placeholder={tStoryInfoEditor('dedicationPlaceholder')}
+              placeholder={tStoryInfoEditor("dedicationPlaceholder")}
             />
           </div>
 
@@ -155,35 +160,55 @@ export default function StoryInfoEditor({
           <div className="space-y-2">
             <label className="block text-sm font-medium text-base-content flex items-center gap-2">
               <FiUser className="w-4 h-4" />
-              {tStoryInfoEditor('authorName')}
+              {tStoryInfoEditor("authorName")}
             </label>
             <input
               type="text"
               value={formData.customAuthor}
-              onChange={(e) => handleInputChange('customAuthor', e.target.value)}
+              onChange={(e) =>
+                handleInputChange("customAuthor", e.target.value)
+              }
               className="input input-bordered w-full"
-              placeholder={tStoryInfoEditor('authorPlaceholder')}
+              placeholder={tStoryInfoEditor("authorPlaceholder")}
             />
           </div>
 
           {/* Target Audience */}
           <div className="space-y-2">
             <label className="block text-sm font-medium text-base-content">
-              {tStoryInfoEditor('targetAudience')}
+              {tStoryInfoEditor("targetAudience")}
             </label>
             <select
               value={formData.targetAudience}
-              onChange={(e) => handleInputChange('targetAudience', e.target.value)}
+              onChange={(e) =>
+                handleInputChange("targetAudience", e.target.value)
+              }
               className="select select-bordered w-full"
             >
-              <option value="">{tStoryInfoEditor('targetAudiencePlaceholder')}</option>
-              <option value="children_0-2">{tStoryInfoEditor('targetAudienceOptions.children_0-2')}</option>
-              <option value="children_3-6">{tStoryInfoEditor('targetAudienceOptions.children_3-6')}</option>
-              <option value="children_7-10">{tStoryInfoEditor('targetAudienceOptions.children_7-10')}</option>
-              <option value="children_11-14">{tStoryInfoEditor('targetAudienceOptions.children_11-14')}</option>
-              <option value="young_adult_15-17">{tStoryInfoEditor('targetAudienceOptions.young_adult_15-17')}</option>
-              <option value="adult_18+">{tStoryInfoEditor('targetAudienceOptions.adult_18+')}</option>
-              <option value="all_ages">{tStoryInfoEditor('targetAudienceOptions.all_ages')}</option>
+              <option value="">
+                {tStoryInfoEditor("targetAudiencePlaceholder")}
+              </option>
+              <option value="children_0-2">
+                {tStoryInfoEditor("targetAudienceOptions.children_0-2")}
+              </option>
+              <option value="children_3-6">
+                {tStoryInfoEditor("targetAudienceOptions.children_3-6")}
+              </option>
+              <option value="children_7-10">
+                {tStoryInfoEditor("targetAudienceOptions.children_7-10")}
+              </option>
+              <option value="children_11-14">
+                {tStoryInfoEditor("targetAudienceOptions.children_11-14")}
+              </option>
+              <option value="young_adult_15-17">
+                {tStoryInfoEditor("targetAudienceOptions.young_adult_15-17")}
+              </option>
+              <option value="adult_18+">
+                {tStoryInfoEditor("targetAudienceOptions.adult_18+")}
+              </option>
+              <option value="all_ages">
+                {tStoryInfoEditor("targetAudienceOptions.all_ages")}
+              </option>
             </select>
           </div>
         </div>
@@ -193,15 +218,15 @@ export default function StoryInfoEditor({
           {/* Front Cover */}
           <div className="space-y-2">
             <label className="block text-sm font-medium text-base-content">
-              {tStoryInfoEditor('frontCover')}
+              {tStoryInfoEditor("frontCover")}
             </label>
             <div className="border-2 border-dashed border-base-300 rounded-lg p-4 text-center w-full">
               {story.coverUri ? (
                 <div className="space-y-2">
                   <div className="relative mx-auto max-h-48 w-fit">
                     <Image
-                      src={toAbsoluteImageUrl(story.coverUri) || ''}
-                      alt={tStoryInfoEditor('altTexts.storyCover')}
+                      src={toAbsoluteImageUrl(story.coverUri) || ""}
+                      alt={tStoryInfoEditor("altTexts.storyCover")}
                       width={200}
                       height={300}
                       className="max-h-48 rounded-lg object-contain"
@@ -212,19 +237,21 @@ export default function StoryInfoEditor({
                     className="btn btn-sm btn-outline"
                   >
                     <FiImage className="w-4 h-4" />
-                    {tStoryInfoEditor('editCover')}
+                    {tStoryInfoEditor("editCover")}
                   </button>
                 </div>
               ) : (
                 <div className="space-y-2">
                   <FiImage className="w-12 h-12 mx-auto text-base-content/30" />
-                  <p className="text-sm text-base-content/70">{tStoryInfoEditor('noCoverImage')}</p>
+                  <p className="text-sm text-base-content/70">
+                    {tStoryInfoEditor("noCoverImage")}
+                  </p>
                   <button
                     onClick={onEditCover}
                     className="btn btn-sm btn-primary"
                   >
                     <FiImage className="w-4 h-4" />
-                    {tStoryInfoEditor('addCover')}
+                    {tStoryInfoEditor("addCover")}
                   </button>
                 </div>
               )}
@@ -234,15 +261,15 @@ export default function StoryInfoEditor({
           {/* Back Cover */}
           <div className="space-y-2">
             <label className="block text-sm font-medium text-base-content">
-              {tStoryInfoEditor('backCover')}
+              {tStoryInfoEditor("backCover")}
             </label>
             <div className="border-2 border-dashed border-base-300 rounded-lg p-4 text-center w-full">
               {story.backcoverUri ? (
                 <div className="space-y-2">
                   <div className="relative mx-auto max-h-48 w-fit">
                     <Image
-                      src={toAbsoluteImageUrl(story.backcoverUri) || ''}
-                      alt={tStoryInfoEditor('altTexts.storyBackCover')}
+                      src={toAbsoluteImageUrl(story.backcoverUri) || ""}
+                      alt={tStoryInfoEditor("altTexts.storyBackCover")}
                       width={200}
                       height={300}
                       className="max-h-48 rounded-lg object-contain"
@@ -253,19 +280,21 @@ export default function StoryInfoEditor({
                     className="btn btn-sm btn-outline"
                   >
                     <FiImage className="w-4 h-4" />
-                    {tStoryInfoEditor('editBackCover')}
+                    {tStoryInfoEditor("editBackCover")}
                   </button>
                 </div>
               ) : (
                 <div className="space-y-2">
                   <FiImage className="w-12 h-12 mx-auto text-base-content/30" />
-                  <p className="text-sm text-base-content/70">{tStoryInfoEditor('noBackCover')}</p>
+                  <p className="text-sm text-base-content/70">
+                    {tStoryInfoEditor("noBackCover")}
+                  </p>
                   <button
                     onClick={onEditBackcover}
                     className="btn btn-sm btn-primary"
                   >
                     <FiImage className="w-4 h-4" />
-                    {tStoryInfoEditor('addBackCover')}
+                    {tStoryInfoEditor("addBackCover")}
                   </button>
                 </div>
               )}
@@ -275,34 +304,47 @@ export default function StoryInfoEditor({
 
         {/* Story Info */}
         <div className="bg-base-200 rounded-lg p-4 space-y-2">
-          <h3 className="font-medium">{tStoryInfoEditor('storyDetails')}</h3>
+          <h3 className="font-medium">{tStoryInfoEditor("storyDetails")}</h3>
           <div className="space-y-1 text-sm">
             <div className="flex justify-between items-center">
-              <span className="text-base-content/70">{tStoryInfoEditor('language')}</span>
+              <span className="text-base-content/70">
+                {tStoryInfoEditor("language")}
+              </span>
               <span className="flex items-center gap-2">
                 <button
                   type="button"
                   className="btn btn-ghost btn-xs"
                   onClick={onTranslateClick}
-                  title={tStoryInfoEditor('translate')}
+                  title={tStoryInfoEditor("translate")}
                 >
                   <FiGlobe className="w-4 h-4" />
-                  <span className="ml-1 hidden sm:inline">{tStoryInfoEditor('translate')}</span>
+                  <span className="ml-1 hidden sm:inline">
+                    {tStoryInfoEditor("translate")}
+                  </span>
                 </button>
-                <span>{story.storyLanguage || '—'}</span>
+                <span>{story.storyLanguage || "—"}</span>
               </span>
             </div>
             <div className="flex justify-between">
-              <span className="text-base-content/70">{tStoryInfoEditor('graphicalStyleLabel')}</span>
-              <span>{story.graphicalStyle?.replace('_', ' ') || tStoryInfoEditor('notSpecified')}</span>
+              <span className="text-base-content/70">
+                {tStoryInfoEditor("graphicalStyleLabel")}
+              </span>
+              <span>
+                {story.graphicalStyle?.replace("_", " ") ||
+                  tStoryInfoEditor("notSpecified")}
+              </span>
             </div>
             <div className="flex justify-between">
-              <span className="text-base-content/70">{tStoryInfoEditor('created')}</span>
-              <span>{new Date(story.createdAt).toLocaleDateString()}</span>
+              <span className="text-base-content/70">
+                {tStoryInfoEditor("created")}
+              </span>
+              <span>{formatDate(story.createdAt)}</span>
             </div>
             <div className="flex justify-between">
-              <span className="text-base-content/70">{tStoryInfoEditor('lastUpdated')}</span>
-              <span>{new Date(story.updatedAt).toLocaleDateString()}</span>
+              <span className="text-base-content/70">
+                {tStoryInfoEditor("lastUpdated")}
+              </span>
+              <span>{formatDate(story.updatedAt)}</span>
             </div>
           </div>
         </div>

--- a/src/components/StoryRating.tsx
+++ b/src/components/StoryRating.tsx
@@ -1,13 +1,14 @@
-'use client';
+"use client";
 
-import { useState, useEffect } from 'react';
-import { useTranslations } from 'next-intl';
-import { FiStar } from 'react-icons/fi';
-import { 
-  getAnonymousRating, 
-  setAnonymousRating, 
-  areCookiesSupported 
-} from '@/utils/cookieUtils';
+import { useState, useEffect } from "react";
+import { useTranslations } from "next-intl";
+import { FiStar } from "react-icons/fi";
+import {
+  getAnonymousRating,
+  setAnonymousRating,
+  areCookiesSupported,
+} from "@/utils/cookieUtils";
+import { formatDate } from "@/utils/date";
 
 interface StoryRatingProps {
   storyId: string;
@@ -27,18 +28,23 @@ interface AnonymousRating {
   createdAt: string;
 }
 
-export default function StoryRating({ storyId, onRatingSubmitted }: StoryRatingProps) {
-  const tCommonStoryRating = useTranslations('StoryRating');
+export default function StoryRating({
+  storyId,
+  onRatingSubmitted,
+}: StoryRatingProps) {
+  const tCommonStoryRating = useTranslations("StoryRating");
   const [rating, setRating] = useState<number>(0);
   const [hoveredRating, setHoveredRating] = useState<number>(0);
-  const [feedback, setFeedback] = useState<string>('');
-  const [includeNameInFeedback, setIncludeNameInFeedback] = useState<boolean>(false);
+  const [feedback, setFeedback] = useState<string>("");
+  const [includeNameInFeedback, setIncludeNameInFeedback] =
+    useState<boolean>(false);
   const [showFeedbackForm, setShowFeedbackForm] = useState<boolean>(false);
   const [isSubmitting, setIsSubmitting] = useState<boolean>(false);
   const [submitted, setSubmitted] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
   const [existingRating, setExistingRating] = useState<UserRating | null>(null);
-  const [anonymousRating, setAnonymousRatingState] = useState<AnonymousRating | null>(null);
+  const [anonymousRating, setAnonymousRatingState] =
+    useState<AnonymousRating | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [cookiesSupported, setCookiesSupported] = useState<boolean>(true);
 
@@ -56,7 +62,7 @@ export default function StoryRating({ storyId, onRatingSubmitted }: StoryRatingP
           if (anonymousRatingData) {
             setAnonymousRatingState(anonymousRatingData);
             setRating(parseInt(anonymousRatingData.rating));
-            setFeedback(anonymousRatingData.feedback || '');
+            setFeedback(anonymousRatingData.feedback || "");
             setLoading(false);
             return;
           }
@@ -69,11 +75,11 @@ export default function StoryRating({ storyId, onRatingSubmitted }: StoryRatingP
           if (data.userRating) {
             setExistingRating(data.userRating);
             setRating(parseInt(data.userRating.rating));
-            setFeedback(data.userRating.feedback || '');
+            setFeedback(data.userRating.feedback || "");
           }
         }
       } catch (error) {
-        console.error('Error fetching existing rating:', error);
+        console.error("Error fetching existing rating:", error);
       } finally {
         setLoading(false);
       }
@@ -85,7 +91,7 @@ export default function StoryRating({ storyId, onRatingSubmitted }: StoryRatingP
   const handleStarClick = (starRating: number) => {
     setRating(starRating);
     setError(null);
-    
+
     // Show feedback form for ratings 1-3
     if (starRating <= 3) {
       setShowFeedbackForm(true);
@@ -95,15 +101,18 @@ export default function StoryRating({ storyId, onRatingSubmitted }: StoryRatingP
     }
   };
 
-  const handleSubmitRating = async (finalRating: number = rating, finalFeedback: string = feedback) => {
+  const handleSubmitRating = async (
+    finalRating: number = rating,
+    finalFeedback: string = feedback,
+  ) => {
     setIsSubmitting(true);
     setError(null);
 
     try {
       const response = await fetch(`/api/stories/${storyId}/ratings`, {
-        method: 'POST',
+        method: "POST",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
         body: JSON.stringify({
           rating: finalRating.toString(),
@@ -115,13 +124,17 @@ export default function StoryRating({ storyId, onRatingSubmitted }: StoryRatingP
       if (!response.ok) {
         const errorData = await response.json();
         if (response.status === 503) {
-          throw new Error(tCommonStoryRating('errors.serviceUnavailable'));
+          throw new Error(tCommonStoryRating("errors.serviceUnavailable"));
         }
-        
+
         // Check if this is an anonymous user (no authentication)
         if (response.status === 401 && cookiesSupported) {
           // Store rating in cookie for anonymous users
-          setAnonymousRating(storyId, finalRating.toString(), finalFeedback || undefined);
+          setAnonymousRating(
+            storyId,
+            finalRating.toString(),
+            finalFeedback || undefined,
+          );
           setAnonymousRatingState({
             rating: finalRating.toString(),
             feedback: finalFeedback || undefined,
@@ -132,8 +145,10 @@ export default function StoryRating({ storyId, onRatingSubmitted }: StoryRatingP
           setShowFeedbackForm(false);
           return;
         }
-        
-        throw new Error(errorData.error || tCommonStoryRating('errors.submitFailed'));
+
+        throw new Error(
+          errorData.error || tCommonStoryRating("errors.submitFailed"),
+        );
       }
 
       const result = await response.json();
@@ -145,11 +160,15 @@ export default function StoryRating({ storyId, onRatingSubmitted }: StoryRatingP
       });
       setSubmitted(true);
       onRatingSubmitted?.(finalRating);
-      
+
       // Reset form state after successful submission
       setShowFeedbackForm(false);
     } catch (err) {
-      setError(err instanceof Error ? err.message : tCommonStoryRating('errors.generic'));
+      setError(
+        err instanceof Error
+          ? err.message
+          : tCommonStoryRating("errors.generic"),
+      );
     } finally {
       setIsSubmitting(false);
     }
@@ -174,14 +193,19 @@ export default function StoryRating({ storyId, onRatingSubmitted }: StoryRatingP
     return (
       <div className="card bg-success/10 border border-success/20 shadow-lg">
         <div className="card-body text-center">
-          <div className="text-success text-4xl mb-2">✓</div>          
+          <div className="text-success text-4xl mb-2">✓</div>
           <h3 className="card-title text-success justify-center">
-            {(existingRating || anonymousRating) ? (tCommonStoryRating('success.titleUpdated') || 'Rating Updated!') : tCommonStoryRating('success.title')}
+            {existingRating || anonymousRating
+              ? tCommonStoryRating("success.titleUpdated") || "Rating Updated!"
+              : tCommonStoryRating("success.title")}
           </h3>
           <p className="text-success/80">
-            {(existingRating || anonymousRating) ? (tCommonStoryRating('success.messageUpdated') || 'Your rating has been updated successfully!') : tCommonStoryRating('success.message')}
+            {existingRating || anonymousRating
+              ? tCommonStoryRating("success.messageUpdated") ||
+                "Your rating has been updated successfully!"
+              : tCommonStoryRating("success.message")}
           </p>
-          
+
           {/* Allow user to submit another rating only for authenticated users */}
           {existingRating && (
             <button
@@ -195,11 +219,12 @@ export default function StoryRating({ storyId, onRatingSubmitted }: StoryRatingP
               Update Rating
             </button>
           )}
-          
+
           {/* Show message for anonymous users */}
           {anonymousRating && !existingRating && (
             <p className="text-sm text-base-content/60 mt-4">
-              {tCommonStoryRating('anonymous.thankYou') || 'Thank you for your feedback!'}
+              {tCommonStoryRating("anonymous.thankYou") ||
+                "Thank you for your feedback!"}
             </p>
           )}
         </div>
@@ -212,17 +237,20 @@ export default function StoryRating({ storyId, onRatingSubmitted }: StoryRatingP
       <div className="card-body">
         <div className="text-center">
           <h3 className="card-title justify-center mb-4">
-            {(existingRating || anonymousRating) ? (tCommonStoryRating('titleUpdate') || 'Update Your Rating') : tCommonStoryRating('title')}
+            {existingRating || anonymousRating
+              ? tCommonStoryRating("titleUpdate") || "Update Your Rating"
+              : tCommonStoryRating("title")}
           </h3>
-          
+
           {/* Show existing rating info for authenticated users */}
           {existingRating && !submitted && (
             <div className="mb-4 p-3 bg-info/10 rounded-lg border border-info/20">
               <p className="text-sm text-info">
-                {tCommonStoryRating('currentRating') || 'Current Rating'}: {existingRating.rating} ⭐ 
+                {tCommonStoryRating("currentRating") || "Current Rating"}:{" "}
+                {existingRating.rating} ⭐
                 {existingRating.createdAt && (
                   <span className="ml-2 text-xs">
-                    ({new Date(existingRating.createdAt).toLocaleDateString()})
+                    ({formatDate(existingRating.createdAt)})
                   </span>
                 )}
               </p>
@@ -238,10 +266,12 @@ export default function StoryRating({ storyId, onRatingSubmitted }: StoryRatingP
           {anonymousRating && !existingRating && !submitted && (
             <div className="mb-4 p-3 bg-warning/10 rounded-lg border border-warning/20">
               <p className="text-sm text-warning">
-                {tCommonStoryRating('anonymous.alreadyRated') || 'You have already rated this story'}: {anonymousRating.rating} ⭐ 
+                {tCommonStoryRating("anonymous.alreadyRated") ||
+                  "You have already rated this story"}
+                : {anonymousRating.rating} ⭐
                 {anonymousRating.createdAt && (
                   <span className="ml-2 text-xs">
-                    ({new Date(anonymousRating.createdAt).toLocaleDateString()})
+                    ({formatDate(anonymousRating.createdAt)})
                   </span>
                 )}
               </p>
@@ -251,7 +281,8 @@ export default function StoryRating({ storyId, onRatingSubmitted }: StoryRatingP
                 </p>
               )}
               <p className="text-xs text-warning/80 mt-2">
-                {tCommonStoryRating('anonymous.cannotChange') || 'Anonymous ratings cannot be changed. Please sign in to update your rating.'}
+                {tCommonStoryRating("anonymous.cannotChange") ||
+                  "Anonymous ratings cannot be changed. Please sign in to update your rating."}
               </p>
             </div>
           )}
@@ -260,11 +291,12 @@ export default function StoryRating({ storyId, onRatingSubmitted }: StoryRatingP
           {!cookiesSupported && !existingRating && (
             <div className="mb-4 p-3 bg-error/10 rounded-lg border border-error/20">
               <p className="text-sm text-error">
-                {tCommonStoryRating('cookies.disabled') || 'Cookies are disabled. Multiple ratings may be allowed.'}
+                {tCommonStoryRating("cookies.disabled") ||
+                  "Cookies are disabled. Multiple ratings may be allowed."}
               </p>
             </div>
           )}
-          
+
           {/* Star Rating */}
           <div className="flex justify-center gap-1 mb-4">
             {[1, 2, 3, 4, 5].map((star) => (
@@ -273,16 +305,20 @@ export default function StoryRating({ storyId, onRatingSubmitted }: StoryRatingP
                 type="button"
                 className={`btn btn-ghost p-2 text-3xl transition-colors ${
                   star <= (hoveredRating || rating)
-                    ? 'text-warning'
-                    : 'text-base-300'
+                    ? "text-warning"
+                    : "text-base-300"
                 }`}
                 onClick={() => handleStarClick(star)}
                 onMouseEnter={() => setHoveredRating(star)}
                 onMouseLeave={() => setHoveredRating(0)}
-                disabled={isSubmitting || (!!anonymousRating && !existingRating)}
+                disabled={
+                  isSubmitting || (!!anonymousRating && !existingRating)
+                }
               >
-                <FiStar 
-                  className={star <= (hoveredRating || rating) ? 'fill-current' : ''} 
+                <FiStar
+                  className={
+                    star <= (hoveredRating || rating) ? "fill-current" : ""
+                  }
                 />
               </button>
             ))}
@@ -294,13 +330,13 @@ export default function StoryRating({ storyId, onRatingSubmitted }: StoryRatingP
               <div className="text-left">
                 <label htmlFor="feedback" className="label">
                   <span className="label-text">
-                    {tCommonStoryRating('feedback.title')}
+                    {tCommonStoryRating("feedback.title")}
                   </span>
                 </label>
                 <textarea
                   id="feedback"
                   className="textarea textarea-bordered w-full h-24 resize-none"
-                  placeholder={tCommonStoryRating('feedback.placeholder')}
+                  placeholder={tCommonStoryRating("feedback.placeholder")}
                   value={feedback}
                   onChange={(e) => setFeedback(e.target.value)}
                   disabled={isSubmitting}
@@ -317,7 +353,7 @@ export default function StoryRating({ storyId, onRatingSubmitted }: StoryRatingP
                     disabled={isSubmitting}
                   />
                   <span className="label-text">
-                    {tCommonStoryRating('feedback.includeNameLabel')}
+                    {tCommonStoryRating("feedback.includeNameLabel")}
                   </span>
                 </label>
               </div>
@@ -329,7 +365,7 @@ export default function StoryRating({ storyId, onRatingSubmitted }: StoryRatingP
                   onClick={() => setShowFeedbackForm(false)}
                   disabled={isSubmitting}
                 >
-                  {tCommonStoryRating('buttons.cancel')}
+                  {tCommonStoryRating("buttons.cancel")}
                 </button>
                 <button
                   type="submit"
@@ -339,10 +375,13 @@ export default function StoryRating({ storyId, onRatingSubmitted }: StoryRatingP
                   {isSubmitting ? (
                     <>
                       <span className="loading loading-spinner loading-sm"></span>
-                      {tCommonStoryRating('buttons.submitting')}
+                      {tCommonStoryRating("buttons.submitting")}
                     </>
+                  ) : existingRating || anonymousRating ? (
+                    tCommonStoryRating("buttons.updateRating") ||
+                    "Update Rating"
                   ) : (
-                    (existingRating || anonymousRating) ? (tCommonStoryRating('buttons.updateRating') || 'Update Rating') : tCommonStoryRating('buttons.submitRating')
+                    tCommonStoryRating("buttons.submitRating")
                   )}
                 </button>
               </div>
@@ -360,7 +399,7 @@ export default function StoryRating({ storyId, onRatingSubmitted }: StoryRatingP
           {isSubmitting && !showFeedbackForm && (
             <div className="flex items-center justify-center gap-2 mt-4">
               <span className="loading loading-spinner loading-sm"></span>
-              <span>{tCommonStoryRating('submittingMessage')}</span>
+              <span>{tCommonStoryRating("submittingMessage")}</span>
             </div>
           )}
         </div>

--- a/src/components/my-stories/StoryRow.tsx
+++ b/src/components/my-stories/StoryRow.tsx
@@ -1,9 +1,9 @@
-'use client';
+"use client";
 
-import { useState, useEffect, useMemo } from 'react';
-import Link from 'next/link';
-import { useTranslations } from 'next-intl';
-import { useLocale } from 'next-intl';
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { useTranslations } from "next-intl";
+import { useLocale } from "next-intl";
 import {
   FiEdit3,
   FiTrash2,
@@ -12,8 +12,9 @@ import {
   FiPrinter,
   FiMoreVertical,
   FiCopy,
-} from 'react-icons/fi';
-import { Story } from '@/types/story';
+} from "react-icons/fi";
+import { Story } from "@/types/story";
+import { formatDate, FormatOptions } from "@/utils/date";
 
 interface StoryRowProps {
   story: Story;
@@ -32,13 +33,16 @@ export default function StoryRow({
   onPrint,
   onDuplicate,
 }: StoryRowProps) {
-  const tMyStoriesPage = useTranslations('MyStoriesPage');
-  const tCommonShare = useTranslations('Share');
-  const tCommonActions = useTranslations('Actions');
+  const tMyStoriesPage = useTranslations("MyStoriesPage");
+  const tCommonShare = useTranslations("Share");
+  const tCommonActions = useTranslations("Actions");
   const locale = useLocale();
 
   const [openMenu, setOpenMenu] = useState(false);
-  const [menuPosition, setMenuPosition] = useState<{ top: number; right: number } | null>(null);
+  const [menuPosition, setMenuPosition] = useState<{
+    top: number;
+    right: number;
+  } | null>(null);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -46,62 +50,69 @@ export default function StoryRow({
       if (
         openMenu &&
         !target.closest(`[data-story-menu="${story.storyId}"]`) &&
-        !target.closest('.fixed')
+        !target.closest(".fixed")
       ) {
         setOpenMenu(false);
         setMenuPosition(null);
       }
     };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
   }, [openMenu, story.storyId]);
 
-  const desktopDateFormatter = useMemo(
-    () =>
-      new Intl.DateTimeFormat(locale, {
-        day: '2-digit',
-        month: '2-digit',
-        year: '2-digit',
-      }),
-    [locale],
-  );
-
-  const mobileDateFormatter = useMemo(
-    () =>
-      new Intl.DateTimeFormat(locale, {
-        day: '2-digit',
-        month: '2-digit',
-      }),
-    [locale],
-  );
-
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    if (isNaN(date.getTime())) return '-';
-    return isMobile ? mobileDateFormatter.format(date) : desktopDateFormatter.format(date);
+  const desktopDateOptions: FormatOptions = {
+    day: "2-digit",
+    month: "2-digit",
+    year: "2-digit",
+    locale,
+  };
+  const mobileDateOptions: FormatOptions = {
+    day: "2-digit",
+    month: "2-digit",
+    locale,
   };
 
   const getStatusBadgeClass = (status: string) => {
     switch (status) {
-      case 'draft':
-        return 'badge badge-secondary';
-      case 'writing':
-        return 'badge badge-warning';
-      case 'published':
-        return 'badge badge-success';
+      case "draft":
+        return "badge badge-secondary";
+      case "writing":
+        return "badge badge-warning";
+      case "published":
+        return "badge badge-success";
       default:
-        return 'badge badge-ghost';
+        return "badge badge-ghost";
     }
   };
 
   const getGenerationStatusInfo = (s: Story) => {
     if (!s.storyGenerationStatus) return null;
     const statusMap = {
-      queued: { text: tMyStoriesPage('table.status.queued'), class: 'badge-info', icon: '⏳' },
-      running: { text: tMyStoriesPage('table.status.running'), class: 'badge-warning', icon: '🔄' },
-      completed: { text: tMyStoriesPage('table.status.completed'), class: 'badge-success', icon: '✅' },
-      failed: { text: tMyStoriesPage('table.status.failed'), class: 'badge-error', icon: '❌' },
-      cancelled: { text: tMyStoriesPage('table.status.cancelled'), class: 'badge-neutral', icon: '⏹️' },
+      queued: {
+        text: tMyStoriesPage("table.status.queued"),
+        class: "badge-info",
+        icon: "⏳",
+      },
+      running: {
+        text: tMyStoriesPage("table.status.running"),
+        class: "badge-warning",
+        icon: "🔄",
+      },
+      completed: {
+        text: tMyStoriesPage("table.status.completed"),
+        class: "badge-success",
+        icon: "✅",
+      },
+      failed: {
+        text: tMyStoriesPage("table.status.failed"),
+        class: "badge-error",
+        icon: "❌",
+      },
+      cancelled: {
+        text: tMyStoriesPage("table.status.cancelled"),
+        class: "badge-neutral",
+        icon: "⏹️",
+      },
     } as const;
     const info = statusMap[s.storyGenerationStatus];
     return { ...info, percentage: s.storyGenerationCompletedPercentage || 0 };
@@ -109,9 +120,14 @@ export default function StoryRow({
 
   return (
     <tr>
-      <td className="px-2 py-1 md:px-4 md:py-2">{formatDate(story.createdAt)}</td>
+      <td className="px-2 py-1 md:px-4 md:py-2">
+        {formatDate(
+          story.createdAt,
+          isMobile ? mobileDateOptions : desktopDateOptions,
+        )}
+      </td>
       <td className="font-medium px-2 py-1 md:px-4 md:py-2">
-        {story.status === 'published' ? (
+        {story.status === "published" ? (
           <Link
             href={`/${locale}/stories/${story.storyId}`}
             className="text-primary hover:text-primary-focus hover:underline cursor-pointer"
@@ -124,27 +140,34 @@ export default function StoryRow({
       </td>
       <td className="px-2 py-1 md:px-4 md:py-2 whitespace-nowrap">
         <div className="space-y-1">
-          <span className={`${getStatusBadgeClass(story.status)} badge-sm text-xs whitespace-nowrap`}>
+          <span
+            className={`${getStatusBadgeClass(story.status)} badge-sm text-xs whitespace-nowrap`}
+          >
             {tMyStoriesPage(`status.${story.status}`)}
           </span>
           {(() => {
             const genStatus = getGenerationStatusInfo(story);
-            if (genStatus && story.status === 'writing') {
+            if (genStatus && story.status === "writing") {
               return (
                 <div className="flex flex-col space-y-1">
-                  <span className={`badge badge-xs ${genStatus.class} whitespace-nowrap`}>
+                  <span
+                    className={`badge badge-xs ${genStatus.class} whitespace-nowrap`}
+                  >
                     {genStatus.icon} {genStatus.text}
                   </span>
-                  {genStatus.percentage > 0 && genStatus.text === 'Generating' && (
-                    <div className="w-full">
-                      <progress
-                        className="progress progress-primary w-full h-2"
-                        value={genStatus.percentage}
-                        max="100"
-                      ></progress>
-                      <span className="text-xs text-gray-500">{genStatus.percentage}%</span>
-                    </div>
-                  )}
+                  {genStatus.percentage > 0 &&
+                    genStatus.text === "Generating" && (
+                      <div className="w-full">
+                        <progress
+                          className="progress progress-primary w-full h-2"
+                          value={genStatus.percentage}
+                          max="100"
+                        ></progress>
+                        <span className="text-xs text-gray-500">
+                          {genStatus.percentage}%
+                        </span>
+                      </div>
+                    )}
                 </div>
               );
             }
@@ -155,14 +178,14 @@ export default function StoryRow({
       <td className="pl-2 pr-1 py-1 md:px-4 md:py-2">
         <div className="hidden md:flex justify-end gap-0.5">
           <button
-            className={`btn btn-ghost btn-sm ${story.status !== 'published' ? 'btn-disabled' : ''}`}
-            onClick={() => story.status === 'published' && onDuplicate(story)}
-            title={tMyStoriesPage('actions.duplicate')}
-            disabled={story.status !== 'published'}
+            className={`btn btn-ghost btn-sm ${story.status !== "published" ? "btn-disabled" : ""}`}
+            onClick={() => story.status === "published" && onDuplicate(story)}
+            title={tMyStoriesPage("actions.duplicate")}
+            disabled={story.status !== "published"}
           >
             <FiCopy className="w-4 h-4" />
           </button>
-          {story.status === 'published' && (
+          {story.status === "published" && (
             <Link
               href={`/${locale}/stories/${story.storyId}`}
               className="btn btn-ghost btn-sm text-primary hover:bg-primary hover:text-primary-content"
@@ -171,19 +194,19 @@ export default function StoryRow({
               <FiBook className="w-4 h-4" />
             </Link>
           )}
-          {story.status === 'writing' ? (
+          {story.status === "writing" ? (
             <button
               className="btn btn-ghost btn-sm btn-disabled"
               disabled
-              title={tCommonShare('tooltips.cannotShareWriting')}
+              title={tCommonShare("tooltips.cannotShareWriting")}
             >
               <FiShare2 className="w-4 h-4" />
             </button>
-          ) : story.status === 'draft' ? (
+          ) : story.status === "draft" ? (
             <button
               className="btn btn-ghost btn-sm btn-disabled"
               disabled
-              title={tCommonShare('tooltips.cannotShareDraft')}
+              title={tCommonShare("tooltips.cannotShareDraft")}
             >
               <FiShare2 className="w-4 h-4" />
             </button>
@@ -191,16 +214,16 @@ export default function StoryRow({
             <button
               className="btn btn-ghost btn-sm"
               onClick={() => onShare(story)}
-              title={tMyStoriesPage('actions.share')}
+              title={tMyStoriesPage("actions.share")}
             >
               <FiShare2 className="w-4 h-4" />
             </button>
           )}
-          {story.status === 'published' ? (
+          {story.status === "published" ? (
             <button
               className="btn btn-ghost btn-sm"
               onClick={() => onPrint(story)}
-              title={tMyStoriesPage('actions.print')}
+              title={tMyStoriesPage("actions.print")}
             >
               <FiPrinter className="w-4 h-4" />
             </button>
@@ -208,12 +231,12 @@ export default function StoryRow({
             <button
               className="btn btn-ghost btn-sm btn-disabled"
               disabled
-              title={tMyStoriesPage('actions.printNotAvailable')}
+              title={tMyStoriesPage("actions.printNotAvailable")}
             >
               <FiPrinter className="w-4 h-4" />
             </button>
           )}
-          {story.status === 'writing' ? (
+          {story.status === "writing" ? (
             <button
               className="btn btn-ghost btn-sm btn-disabled"
               disabled
@@ -221,11 +244,11 @@ export default function StoryRow({
             >
               <FiEdit3 className="w-4 h-4" />
             </button>
-          ) : story.status === 'draft' ? (
+          ) : story.status === "draft" ? (
             <Link
               href={`/${locale}/tell-your-story/step-3?edit=${story.storyId}`}
               className="btn btn-ghost btn-sm"
-              title={tMyStoriesPage('actions.edit')}
+              title={tMyStoriesPage("actions.edit")}
             >
               <FiEdit3 className="w-4 h-4" />
             </Link>
@@ -233,7 +256,7 @@ export default function StoryRow({
             <Link
               href={`/${locale}/stories/edit/${story.storyId}`}
               className="btn btn-ghost btn-sm"
-              title={tMyStoriesPage('actions.edit')}
+              title={tMyStoriesPage("actions.edit")}
             >
               <FiEdit3 className="w-4 h-4" />
             </Link>
@@ -241,7 +264,7 @@ export default function StoryRow({
           <button
             className="btn btn-ghost btn-sm text-error hover:bg-error hover:text-error-content"
             onClick={() => onDelete(story)}
-            title={tMyStoriesPage('actions.delete')}
+            title={tMyStoriesPage("actions.delete")}
           >
             <FiTrash2 className="w-4 h-4" />
           </button>
@@ -264,20 +287,23 @@ export default function StoryRow({
           {openMenu && menuPosition && (
             <div
               className="fixed z-[9999] bg-base-100 border border-base-300 rounded-lg shadow-xl min-w-48"
-              style={{ top: `${menuPosition.top}px`, right: `${menuPosition.right}px` }}
+              style={{
+                top: `${menuPosition.top}px`,
+                right: `${menuPosition.right}px`,
+              }}
             >
               <div className="p-2 space-y-1">
-                {story.status === 'published' && (
+                {story.status === "published" && (
                   <Link
                     href={`/${locale}/stories/${story.storyId}`}
                     className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-base-200 rounded-md"
                     onClick={() => setOpenMenu(false)}
                   >
                     <FiBook className="w-4 h-4" />
-                    {tCommonActions('read')}
+                    {tCommonActions("read")}
                   </Link>
                 )}
-                {story.status === 'published' ? (
+                {story.status === "published" ? (
                   <button
                     className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-base-200 rounded-md w-full text-left"
                     onClick={() => {
@@ -287,15 +313,15 @@ export default function StoryRow({
                     }}
                   >
                     <FiShare2 className="w-4 h-4" />
-                    {tMyStoriesPage('actions.share')}
+                    {tMyStoriesPage("actions.share")}
                   </button>
                 ) : (
                   <div className="flex items-center gap-2 px-3 py-2 text-sm text-base-content/50 rounded-md">
                     <FiShare2 className="w-4 h-4" />
-                    {tMyStoriesPage('actions.share')}
+                    {tMyStoriesPage("actions.share")}
                   </div>
                 )}
-                {story.status === 'published' ? (
+                {story.status === "published" ? (
                   <button
                     className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-base-200 rounded-md w-full text-left"
                     onClick={() => {
@@ -305,20 +331,20 @@ export default function StoryRow({
                     }}
                   >
                     <FiPrinter className="w-4 h-4" />
-                    {tMyStoriesPage('actions.print')}
+                    {tMyStoriesPage("actions.print")}
                   </button>
                 ) : (
                   <div className="flex items-center gap-2 px-3 py-2 text-sm text-base-content/50 rounded-md">
                     <FiPrinter className="w-4 h-4" />
-                    {tMyStoriesPage('actions.print')}
+                    {tMyStoriesPage("actions.print")}
                   </div>
                 )}
-                {story.status === 'writing' ? (
+                {story.status === "writing" ? (
                   <div className="flex items-center gap-2 px-3 py-2 text-sm text-base-content/50 rounded-md">
                     <FiEdit3 className="w-4 h-4" />
-                    {tMyStoriesPage('actions.edit')}
+                    {tMyStoriesPage("actions.edit")}
                   </div>
-                ) : story.status === 'draft' ? (
+                ) : story.status === "draft" ? (
                   <Link
                     href={`/${locale}/tell-your-story/step-3?edit=${story.storyId}`}
                     className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-base-200 rounded-md"
@@ -328,7 +354,7 @@ export default function StoryRow({
                     }}
                   >
                     <FiEdit3 className="w-4 h-4" />
-                    {tMyStoriesPage('actions.edit')}
+                    {tMyStoriesPage("actions.edit")}
                   </Link>
                 ) : (
                   <Link
@@ -340,23 +366,23 @@ export default function StoryRow({
                     }}
                   >
                     <FiEdit3 className="w-4 h-4" />
-                    {tMyStoriesPage('actions.edit')}
+                    {tMyStoriesPage("actions.edit")}
                   </Link>
                 )}
                 <div className="border-t border-base-300 my-1"></div>
                 <button
-                  className={`flex items-center gap-2 px-3 py-2 text-sm rounded-md w-full text-left ${story.status !== 'published' ? 'opacity-50 cursor-not-allowed' : 'hover:bg-base-200'}`}
+                  className={`flex items-center gap-2 px-3 py-2 text-sm rounded-md w-full text-left ${story.status !== "published" ? "opacity-50 cursor-not-allowed" : "hover:bg-base-200"}`}
                   onClick={() => {
-                    if (story.status === 'published') {
+                    if (story.status === "published") {
                       onDuplicate(story);
                     }
                     setOpenMenu(false);
                     setMenuPosition(null);
                   }}
-                  disabled={story.status !== 'published'}
+                  disabled={story.status !== "published"}
                 >
                   <FiCopy className="w-4 h-4" />
-                  {tMyStoriesPage('actions.duplicate')}
+                  {tMyStoriesPage("actions.duplicate")}
                 </button>
                 <button
                   className="flex items-center gap-2 px-3 py-2 text-sm hover:bg-error hover:text-error-content rounded-md w-full text-left text-error"
@@ -367,7 +393,7 @@ export default function StoryRow({
                   }}
                 >
                   <FiTrash2 className="w-4 h-4" />
-                  {tMyStoriesPage('actions.delete')}
+                  {tMyStoriesPage("actions.delete")}
                 </button>
               </div>
             </div>

--- a/src/utils/date.test.ts
+++ b/src/utils/date.test.ts
@@ -1,0 +1,31 @@
+import { formatDate } from "@/utils/date";
+
+describe("formatDate", () => {
+  it("formats date with locale and options", () => {
+    expect(
+      formatDate("2024-06-17T12:34:56Z", {
+        locale: "en-US",
+        timeZone: "UTC",
+        year: "numeric",
+        month: "short",
+        day: "numeric",
+      }),
+    ).toBe("Jun 17, 2024");
+  });
+
+  it("formats using different locale", () => {
+    expect(
+      formatDate("2024-06-17T12:34:56Z", {
+        locale: "de-DE",
+        timeZone: "UTC",
+        day: "2-digit",
+        month: "2-digit",
+        year: "2-digit",
+      }),
+    ).toBe("17.06.24");
+  });
+
+  it("returns dash for invalid dates", () => {
+    expect(formatDate("invalid-date")).toBe("-");
+  });
+});

--- a/src/utils/date.ts
+++ b/src/utils/date.ts
@@ -1,0 +1,16 @@
+export interface FormatOptions extends Intl.DateTimeFormatOptions {
+  locale?: string;
+}
+
+export function formatDate(
+  date: string | Date,
+  options: FormatOptions = {},
+): string {
+  const { locale = "en-US", ...formatOptions } = options;
+  const d =
+    typeof date === "string" || typeof date === "number"
+      ? new Date(date)
+      : date;
+  if (isNaN(d.getTime())) return "-";
+  return new Intl.DateTimeFormat(locale, formatOptions).format(d);
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
 // Export utility functions for easy importing
-export * from './enum-normalizers';
-export * from './locale-utils';
+export * from "./enum-normalizers";
+export * from "./locale-utils";
+export * from "./date";


### PR DESCRIPTION
## Summary
- add shared `formatDate` utility
- use shared formatter across components and blog pages to remove duplicated logic
- add unit tests for date formatting

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bffd75a2108328a8cd330dea47c6f1