### PR TITLE
feat: modularize step two media and character flow

### DIFF
--- a/src/app/[locale]/tell-your-story/step-2/CharacterSelection.tsx
+++ b/src/app/[locale]/tell-your-story/step-2/CharacterSelection.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+interface Character {
+  characterId: string;
+  name: string;
+  type?: string;
+  role?: string;
+}
+
+interface Props {
+  onChange: (ids: string[]) => void;
+}
+
+export default function CharacterSelection({ onChange }: Props) {
+  const t = useTranslations('StorySteps.step2');
+  const [existingCharacters, setExistingCharacters] = useState<Character[]>([]);
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+
+  useEffect(() => {
+    const fetchCharacters = async () => {
+      try {
+        setIsLoading(true);
+        const res = await fetch('/api/characters');
+        if (res.ok) {
+          const data = await res.json();
+          if (data.success && data.characters) {
+            setExistingCharacters(data.characters);
+          }
+        }
+      } catch (error) {
+        console.error('Error fetching existing characters:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+    fetchCharacters();
+  }, []);
+
+  const toggle = (id: string) => {
+    setSelectedIds(prev => {
+      const next = prev.includes(id) ? prev.filter(x => x !== id) : [...prev, id];
+      onChange(next);
+      return next;
+    });
+  };
+
+  const selectAll = () => {
+    const ids = existingCharacters.map(c => c.characterId);
+    setSelectedIds(ids);
+    onChange(ids);
+  };
+
+  if (existingCharacters.length === 0 && !isLoading) {
+    return null;
+  }
+
+  return (
+    <div className="bg-gray-50 border border-gray-200 rounded-lg">
+      <div className="p-4 flex items-center gap-3">
+        <span className="text-xl">👥</span>
+        <div>
+          <h3 className="font-semibold text-gray-800">{t('characterSelection.includeExistingTitle')}</h3>
+          <p className="text-sm text-gray-600">
+            {selectedIds.length > 0
+              ? t('characterSelection.selectedCount', { count: selectedIds.length })
+              : t('characterSelection.noneSelected')}
+          </p>
+        </div>
+      </div>
+      <div className="border-t border-gray-200 p-4 max-h-60 overflow-y-auto">
+        {isLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <span className="loading loading-spinner loading-md"></span>
+            <span className="ml-2 text-gray-600">{t('characterSelection.loading')}</span>
+          </div>
+        ) : (
+          <>
+            {existingCharacters.length > 1 && (
+              <div className="mb-3 pb-3 border-b border-gray-200">
+                <label className="flex items-center gap-2 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    className="checkbox checkbox-sm"
+                    checked={selectedIds.length === existingCharacters.length}
+                    onChange={selectAll}
+                  />
+                  <span className="text-sm font-medium text-gray-700">
+                    {t('characterSelection.selectAll', { count: existingCharacters.length })}
+                  </span>
+                </label>
+              </div>
+            )}
+            <div className="space-y-2">
+              {existingCharacters.map(character => (
+                <label key={character.characterId} className="flex items-center gap-3 p-2 rounded-lg hover:bg-gray-100 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    className="checkbox checkbox-sm"
+                    checked={selectedIds.includes(character.characterId)}
+                    onChange={() => toggle(character.characterId)}
+                  />
+                  <div className="flex-1">
+                    <div className="font-medium text-gray-800">{character.name}</div>
+                    {(character.type || character.role) && (
+                      <div className="text-xs text-gray-500">
+                        {[character.type, character.role].filter(Boolean).join(' • ')}
+                      </div>
+                    )}
+                  </div>
+                </label>
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/[locale]/tell-your-story/step-2/MediaCapture.tsx
+++ b/src/app/[locale]/tell-your-story/step-2/MediaCapture.tsx
@@ -1,0 +1,346 @@
+'use client';
+
+import Image from 'next/image';
+import { useRef, useState } from 'react';
+import { useTranslations } from 'next-intl';
+import { UploadedImage, UploadedAudio } from '@/hooks/useStep2Session';
+
+interface Props {
+  activeModal: 'images' | 'audio' | null;
+  setActiveModal: (value: 'images' | 'audio' | null) => void;
+  uploadedImages: UploadedImage[];
+  setUploadedImages: (images: UploadedImage[]) => void;
+  uploadedAudio: UploadedAudio | null;
+  setUploadedAudio: (audio: UploadedAudio | null) => void;
+  saveToSession: () => void;
+}
+
+export default function MediaCapture({
+  activeModal,
+  setActiveModal,
+  uploadedImages,
+  setUploadedImages,
+  uploadedAudio,
+  setUploadedAudio,
+  saveToSession,
+}: Props) {
+  const t = useTranslations('StorySteps.step2');
+  const [isCapturing, setIsCapturing] = useState(false);
+  const [isRecording, setIsRecording] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const audioInputRef = useRef<HTMLInputElement>(null);
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const audioChunksRef = useRef<Blob[]>([]);
+
+  const handleImageUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const files = event.target.files;
+    if (files) {
+      const newImages = Array.from(files).slice(0, 3 - uploadedImages.length);
+      const imagePromises = newImages.map(file => {
+        return new Promise<UploadedImage>((resolve) => {
+          const reader = new FileReader();
+          reader.onload = (e) => {
+            resolve({
+              file,
+              preview: e.target?.result as string,
+            });
+          };
+          reader.readAsDataURL(file);
+        });
+      });
+
+      Promise.all(imagePromises).then(results => {
+        setUploadedImages([...uploadedImages, ...results].slice(0, 3));
+        saveToSession();
+      });
+    }
+  };
+
+  const startCamera = async () => {
+    try {
+      setIsCapturing(true);
+      const stream = await navigator.mediaDevices.getUserMedia({ video: { facingMode: 'environment' } });
+      if (videoRef.current) {
+        videoRef.current.srcObject = stream;
+        videoRef.current.play();
+      }
+    } catch (error) {
+      console.error('Error accessing camera:', error);
+      alert(t('alerts.cameraIssue'));
+      setIsCapturing(false);
+    }
+  };
+
+  const capturePhoto = () => {
+    if (videoRef.current && canvasRef.current && uploadedImages.length < 3) {
+      const video = videoRef.current;
+      const canvas = canvasRef.current;
+      const context = canvas.getContext('2d');
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+      if (context) {
+        context.drawImage(video, 0, 0);
+        canvas.toBlob((blob) => {
+          if (blob) {
+            const file = new File([blob], `captured-photo-${Date.now()}.jpg`, { type: 'image/jpeg' });
+            const preview = canvas.toDataURL();
+            setUploadedImages([...uploadedImages, { file, preview }].slice(0, 3));
+            saveToSession();
+            if (uploadedImages.length >= 2) {
+              stopCamera();
+            }
+          }
+        }, 'image/jpeg', 0.8);
+      }
+    }
+  };
+
+  const stopCamera = () => {
+    if (videoRef.current && videoRef.current.srcObject) {
+      const stream = videoRef.current.srcObject as MediaStream;
+      stream.getTracks().forEach(track => track.stop());
+      videoRef.current.srcObject = null;
+    }
+    setIsCapturing(false);
+  };
+
+  const removeImage = (index: number) => {
+    setUploadedImages(uploadedImages.filter((_, i) => i !== index));
+    saveToSession();
+  };
+
+  const handleAudioUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        setUploadedAudio({ file, preview: e.target?.result as string });
+        saveToSession();
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const clearAudio = () => {
+    setUploadedAudio(null);
+    if (audioInputRef.current) {
+      audioInputRef.current.value = '';
+    }
+    saveToSession();
+  };
+
+  const startRecording = async () => {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const mediaRecorder = new MediaRecorder(stream);
+      mediaRecorderRef.current = mediaRecorder;
+      audioChunksRef.current = [];
+      mediaRecorder.ondataavailable = (event) => {
+        if (event.data.size > 0) {
+          audioChunksRef.current.push(event.data);
+        }
+      };
+      mediaRecorder.onstop = () => {
+        const audioBlob = new Blob(audioChunksRef.current, { type: 'audio/wav' });
+        const audioFile = new File([audioBlob], 'recorded-audio.wav', { type: 'audio/wav' });
+        const audioUrl = URL.createObjectURL(audioBlob);
+        setUploadedAudio({ file: audioFile, preview: audioUrl });
+        saveToSession();
+        stream.getTracks().forEach(track => track.stop());
+      };
+      mediaRecorder.start();
+      setIsRecording(true);
+    } catch (error) {
+      console.error('Error accessing microphone:', error);
+      alert(t('alerts.microphoneIssue'));
+    }
+  };
+
+  const stopRecording = () => {
+    if (mediaRecorderRef.current && isRecording) {
+      mediaRecorderRef.current.stop();
+      setIsRecording(false);
+    }
+  };
+
+  return (
+    <>
+      {activeModal === 'images' && (
+        <div className="modal modal-open">
+          <div className="modal-box max-w-5xl w-11/12 h-[90vh] flex flex-col">
+            <div className="modal-header flex justify-between items-center mb-4">
+              <h3 className="font-bold text-2xl">📸 {t('tabImage')}</h3>
+              <button className="btn btn-sm btn-circle btn-ghost" onClick={() => { setActiveModal(null); stopCamera(); }}>
+                ✕
+              </button>
+            </div>
+            <div className="flex-1 overflow-y-auto">
+              {uploadedImages.length > 0 && (
+                <div className="mb-6">
+                  <h4 className="font-semibold mb-3">{t('imageGalleryTitle', { count: uploadedImages.length })}</h4>
+                  <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                    {uploadedImages.map((img, index) => (
+                      <div key={index} className="relative">
+                        <div className="aspect-video rounded-lg overflow-hidden bg-base-200">
+                          <Image src={img.preview} alt={`Story image ${index + 1}`} fill className="object-cover" />
+                        </div>
+                        <button className="btn btn-sm btn-circle btn-error absolute top-2 right-2" onClick={() => removeImage(index)}>
+                          ✕
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+              {uploadedImages.length < 3 && !isCapturing && (
+                <div className="text-center space-y-4">
+                  <div className="flex flex-col sm:flex-row gap-4 justify-center">
+                    <button className="btn btn-primary btn-lg" onClick={startCamera}>
+                      📷 {t('takePhoto')}
+                    </button>
+                    <button className="btn btn-outline btn-lg" onClick={() => fileInputRef.current?.click()}>
+                      🖼️ {t('uploadImage')}
+                    </button>
+                  </div>
+                  <p className="text-gray-600">{t('imageHelp')}</p>
+                </div>
+              )}
+              {isCapturing && (
+                <div className="text-center space-y-4">
+                  <video ref={videoRef} className="w-full max-w-md mx-auto rounded-lg border" autoPlay playsInline muted />
+                  <div className="flex gap-4 justify-center">
+                    <button className="btn btn-primary btn-lg" onClick={capturePhoto} disabled={uploadedImages.length >= 3}>
+                      {t('buttons.capture')}
+                    </button>
+                    <button className="btn btn-outline btn-lg" onClick={stopCamera}>
+                      {t('buttons.cancel')}
+                    </button>
+                  </div>
+                </div>
+              )}
+              <input ref={fileInputRef} type="file" accept="image/*" onChange={handleImageUpload} multiple className="hidden" />
+              <canvas ref={canvasRef} className="hidden" />
+              <div className="mt-6 p-4 bg-base-200 rounded-lg">
+                <h4 className="font-semibold mb-3">{t('photoTips.title')}</h4>
+                <ul className="text-sm space-y-1 list-disc list-inside">
+                  {(t.raw('photoTips.tips') as string[]).map((tip: string, index: number) => (
+                    <li key={index}>{tip}</li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+            <div className="modal-action">
+              <button
+                className="btn btn-primary"
+                onClick={() => {
+                  setActiveModal(null);
+                  stopCamera();
+                  saveToSession();
+                }}
+              >
+                {t('actions.done')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {activeModal === 'audio' && (
+        <div className="modal modal-open">
+          <div className="modal-box max-w-5xl w-11/12 h-[90vh] flex flex-col">
+            <div className="modal-header flex justify-between items-center mb-4">
+              <h3 className="font-bold text-2xl">🎤 {t('tabRecord')}</h3>
+              <button className="btn btn-sm btn-circle btn-ghost" onClick={() => setActiveModal(null)}>
+                ✕
+              </button>
+            </div>
+            <div className="flex-1 overflow-y-auto">
+              {!uploadedAudio && !isRecording && (
+                <div className="text-center space-y-4">
+                  <div className="flex flex-col sm:flex-row gap-4 justify-center">
+                    <button className="btn btn-primary btn-lg" onClick={startRecording}>
+                      🎤 {t('recordVoice')}
+                    </button>
+                    <button className="btn btn-outline btn-lg" onClick={() => audioInputRef.current?.click()}>
+                      📁 {t('uploadAudio')}
+                    </button>
+                  </div>
+                  <p className="text-gray-600">{t('audioHelp')}</p>
+                </div>
+              )}
+              {isRecording && (
+                <div className="text-center space-y-4">
+                  <div className="flex flex-col items-center space-y-4">
+                    <div className="relative">
+                      <div className="w-32 h-32 bg-red-500 rounded-full flex items-center justify-center animate-pulse">
+                        <div className="text-white text-4xl">🎤</div>
+                      </div>
+                      <div className="absolute inset-0 rounded-full border-4 border-red-500 animate-ping"></div>
+                    </div>
+                    <p className="text-lg font-semibold text-red-600">{t('actions.recording')}</p>
+                    <p className="text-gray-600">{t('recordingHelp')}</p>
+                  </div>
+                  <div className="flex gap-4 justify-center">
+                    <button className="btn btn-error btn-lg" onClick={stopRecording}>
+                      ⏹️ {t('actions.stopRecording')}
+                    </button>
+                  </div>
+                </div>
+              )}
+              {uploadedAudio && (
+                <div className="text-center space-y-4">
+                  <div className="card bg-base-200">
+                    <div className="card-body">
+                      <div className="flex items-center justify-center mb-4">
+                        <div className="text-6xl">🎵</div>
+                      </div>
+                      <audio src={uploadedAudio.preview} controls className="w-full max-w-md mx-auto">
+                        {t('audioSupport.notSupported')}
+                      </audio>
+                      <div className="card-actions justify-center">
+                        <button className="btn btn-outline btn-sm" onClick={clearAudio}>
+                          🗑️ {t('actions.remove')}
+                        </button>
+                        <button className="btn btn-primary btn-sm" onClick={startRecording}>
+                          🔄 {t('actions.recordAgain')}
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+              <input
+                ref={audioInputRef}
+                type="file"
+                accept="audio/mp3,audio/mpeg,audio/wav,audio/m4a"
+                onChange={handleAudioUpload}
+                className="hidden"
+              />
+              <div className="mt-6 p-4 bg-base-200 rounded-lg">
+                <h4 className="font-semibold mb-3">🎤 {t('recordingTips.title')}</h4>
+                <ul className="text-sm space-y-1 list-disc list-inside">
+                  {(t.raw('recordingTips.tips') as string[]).map((tip: string, index: number) => (
+                    <li key={index}>{tip}</li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+            <div className="modal-action">
+              <button
+                className="btn btn-primary"
+                onClick={() => {
+                  setActiveModal(null);
+                  saveToSession();
+                }}
+              >
+                {t('actions.done')}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/app/[locale]/tell-your-story/step-2/WritingTips.tsx
+++ b/src/app/[locale]/tell-your-story/step-2/WritingTips.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
+
+const WRITING_TIPS = [
+  { icon: '🌍', key: 'setting' },
+  { icon: '👥', key: 'characters' },
+  { icon: '⚔️', key: 'conflict' },
+  { icon: '❤️', key: 'emotion' },
+  { icon: '🎭', key: 'twist' },
+  { icon: '🎯', key: 'goal' },
+  { icon: '✨', key: 'magic' },
+];
+
+export default function WritingTips() {
+  const t = useTranslations('StorySteps.step2');
+  const [currentTipIndex, setCurrentTipIndex] = useState(0);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCurrentTipIndex(prev => (prev + 1) % WRITING_TIPS.length);
+    }, 5000);
+    return () => clearInterval(interval);
+  }, []);
+
+  const currentTip = WRITING_TIPS[currentTipIndex];
+
+  return (
+    <div className="p-4 bg-base-200 rounded-lg">
+      <h4 className="font-semibold mb-2 flex items-center gap-2">
+        <span className="text-xl">{currentTip.icon}</span>
+        <span className="text-sm">{t('writingTipsTitle')}</span>
+      </h4>
+      <p className="text-sm leading-relaxed animate-fade-in">
+        {t(`writingTips.${currentTipIndex}.text`)}
+      </p>
+    </div>
+  );
+}

--- a/src/hooks/useMediaUpload.ts
+++ b/src/hooks/useMediaUpload.ts
@@ -1,0 +1,34 @@
+'use client';
+
+interface UploadResult {
+  objectPath: string;
+  dataUrl: string;
+}
+
+export function useMediaUpload() {
+  const fileToDataUrl = (file: File) => new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result as string);
+    reader.onerror = (e) => reject(e);
+    reader.readAsDataURL(file);
+  });
+
+  const uploadMedia = async (storyId: string, kind: 'image' | 'audio', file: File): Promise<UploadResult> => {
+    const contentType = file.type || (kind === 'image' ? 'image/jpeg' : 'audio/wav');
+    const dataUrl = await fileToDataUrl(file);
+    const resp = await fetch('/api/media/signed-upload', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ storyId, kind, contentType, filename: file.name, dataUrl }),
+    });
+    const uploaded = await resp.json();
+    if (!resp.ok || !uploaded?.objectPath) {
+      throw new Error(`${kind} upload failed: ${resp.status}`);
+    }
+    return { objectPath: uploaded.objectPath, dataUrl };
+  };
+
+  return { uploadMedia };
+}
+
+export type { UploadResult };

--- a/src/hooks/useStep2Session.ts
+++ b/src/hooks/useStep2Session.ts
@@ -1,0 +1,82 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+interface UploadedImage {
+  file: File;
+  preview: string;
+}
+
+interface UploadedAudio {
+  file: File;
+  preview: string;
+}
+
+interface SessionData {
+  text: string;
+  images: string[];
+  audio: string | null;
+  lastSaved: number;
+}
+
+export function useStep2Session() {
+  const [storyText, setStoryText] = useState('');
+  const [uploadedImages, setUploadedImages] = useState<UploadedImage[]>([]);
+  const [uploadedAudio, setUploadedAudio] = useState<UploadedAudio | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Load from sessionStorage on mount
+  useEffect(() => {
+    const savedData = sessionStorage.getItem('step2Data');
+    if (savedData) {
+      try {
+        const data: SessionData = JSON.parse(savedData);
+        setStoryText(data.text || '');
+        // Only previews are stored, not actual files
+      } catch (error) {
+        console.error('Error loading saved data:', error);
+      }
+    }
+  }, []);
+
+  const saveToSession = useCallback(() => {
+    setIsSaving(true);
+    const data: SessionData = {
+      text: storyText,
+      images: uploadedImages.map(img => img.preview),
+      audio: uploadedAudio?.preview || null,
+      lastSaved: Date.now(),
+    };
+    sessionStorage.setItem('step2Data', JSON.stringify(data));
+    setTimeout(() => setIsSaving(false), 500);
+  }, [storyText, uploadedImages, uploadedAudio]);
+
+  // Debounced save on text change
+  useEffect(() => {
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current);
+    }
+    saveTimeoutRef.current = setTimeout(() => {
+      saveToSession();
+    }, 10000);
+    return () => {
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+      }
+    };
+  }, [storyText, saveToSession]);
+
+  return {
+    storyText,
+    setStoryText,
+    uploadedImages,
+    setUploadedImages,
+    uploadedAudio,
+    setUploadedAudio,
+    isSaving,
+    saveToSession,
+  };
+}
+
+export type { UploadedImage, UploadedAudio };


### PR DESCRIPTION
## Summary
- extract media capture, character selection, and writing tips into their own components
- add reusable hooks for step two session storage and media uploads
- wire new components and hooks into step two page

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0329f75b083288b95b5e0ded0bd9e