### PR TITLE
feat(utils): centralize chapter conversion

### DIFF
--- a/src/app/[locale]/stories/edit/[storyId]/chapter/[chapterNumber]/page.tsx
+++ b/src/app/[locale]/stories/edit/[storyId]/chapter/[chapterNumber]/page.tsx
@@ -5,6 +5,10 @@ import { useParams, useRouter } from "next/navigation";
 import { useUser } from "@clerk/nextjs";
 import { useTranslations } from "next-intl";
 import { FiArrowLeft, FiRotateCcw, FiRotateCw } from "react-icons/fi";
+import {
+  convertApiChaptersToChapters,
+  type ApiChapter,
+} from "@/utils/chapterConversion";
 
 // Components
 import ChapterEditor from "@/components/chapter-editor/ChapterEditor";
@@ -27,21 +31,6 @@ interface ApiStory {
   backcoverUri?: string;
   targetAudience?: string;
   graphicalStyle?: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
-interface ApiChapter {
-  id: string;
-  chapterNumber: number;
-  title: string;
-  imageUri: string | null;
-  imageThumbnailUri: string | null;
-  htmlContent: string;
-  audioUri: string | null;
-  version: number;
-  hasNextVersion: boolean;
-  hasPreviousVersion: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -73,15 +62,6 @@ export default function EditChapterPage() {
     10,
   );
   const locale = (params?.locale as string | undefined) ?? "";
-
-  // Convert API data to component-compatible format
-  const convertApiChaptersToChapters = (apiChapters: ApiChapter[]) => {
-    return apiChapters.map((chapter) => ({
-      ...chapter,
-      createdAt: new Date(chapter.createdAt),
-      updatedAt: new Date(chapter.updatedAt),
-    }));
-  };
 
   // State
   const [storyData, setStoryData] = useState<ApiResponse | null>(null);

--- a/src/app/[locale]/stories/edit/[storyId]/page.tsx
+++ b/src/app/[locale]/stories/edit/[storyId]/page.tsx
@@ -1,27 +1,31 @@
-'use client';
+"use client";
 
-import AITextStoryEditor from '../../../../../components/AITextStoryEditor';
-import AIImageEditor from '../../../../../components/AIImageEditor';
-import { useEffect, useState, useCallback } from 'react';
-import { useParams, useRouter } from 'next/navigation';
-import { useUser } from '@clerk/nextjs';
-import { useTranslations } from 'next-intl';
-import { FiArrowLeft, FiCopy } from 'react-icons/fi';
+import AITextStoryEditor from "../../../../../components/AITextStoryEditor";
+import AIImageEditor from "../../../../../components/AIImageEditor";
+import { useEffect, useState, useCallback } from "react";
+import { useParams, useRouter } from "next/navigation";
+import { useUser } from "@clerk/nextjs";
+import { useTranslations } from "next-intl";
+import { FiArrowLeft, FiCopy } from "react-icons/fi";
+import {
+  convertApiChaptersToChapters,
+  type ApiChapter,
+} from "@/utils/chapterConversion";
 
 // Components
-import ChapterNavigation from '../../../../../components/ChapterNavigation';
-import StoryInfoEditor from '../../../../../components/StoryInfoEditor';
-import ToastContainer from '../../../../../components/ToastContainer';
-import TranslateFullStoryModal from '../../../../../components/TranslateFullStoryModal';
+import ChapterNavigation from "../../../../../components/ChapterNavigation";
+import StoryInfoEditor from "../../../../../components/StoryInfoEditor";
+import ToastContainer from "../../../../../components/ToastContainer";
+import TranslateFullStoryModal from "../../../../../components/TranslateFullStoryModal";
 
 // Hooks
-import { useToast } from '../../../../../hooks/useToast';
+import { useToast } from "../../../../../hooks/useToast";
 
 // API types (matching the route response)
 interface ApiStory {
   storyId: string;
   title: string;
-  status?: 'draft' | 'writing' | 'published';
+  status?: "draft" | "writing" | "published";
   storyLanguage?: string;
   synopsis?: string;
   dedicationMessage?: string;
@@ -30,21 +34,6 @@ interface ApiStory {
   backcoverUri?: string;
   targetAudience?: string;
   graphicalStyle?: string;
-  createdAt: string;
-  updatedAt: string;
-}
-
-interface ApiChapter {
-  id: string;
-  chapterNumber: number;
-  title: string;
-  imageUri: string | null;
-  imageThumbnailUri: string | null;
-  htmlContent: string;
-  audioUri: string | null;
-  version: number;
-  hasNextVersion: boolean;
-  hasPreviousVersion: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -59,23 +48,14 @@ export default function StoryEditPage() {
   const params = useParams<{ storyId?: string; locale?: string }>();
   const router = useRouter();
   const { user } = useUser();
-  const tLoading = useTranslations('Loading');
-  const tErrors = useTranslations('Errors');
-  const tActions = useTranslations('Actions');
-  const tStoryEditPage = useTranslations('StoryEditPage');
-  const tMyStories = useTranslations('MyStoriesPage');
+  const tLoading = useTranslations("Loading");
+  const tErrors = useTranslations("Errors");
+  const tActions = useTranslations("Actions");
+  const tStoryEditPage = useTranslations("StoryEditPage");
+  const tMyStories = useTranslations("MyStoriesPage");
 
-  const storyId = (params?.storyId as string | undefined) ?? '';
-  const locale = (params?.locale as string | undefined) ?? '';
-
-  // Convert API data to component-compatible format
-  const convertApiChaptersToChapters = (apiChapters: ApiChapter[]) => {
-    return apiChapters.map(chapter => ({
-      ...chapter,
-      createdAt: new Date(chapter.createdAt),
-      updatedAt: new Date(chapter.updatedAt)
-    }));
-  };
+  const storyId = (params?.storyId as string | undefined) ?? "";
+  const locale = (params?.locale as string | undefined) ?? "";
 
   // State
   const [storyData, setStoryData] = useState<ApiResponse | null>(null);
@@ -86,13 +66,19 @@ export default function StoryEditPage() {
   const [showTranslateModal, setShowTranslateModal] = useState(false);
   const [selectedImageData, setSelectedImageData] = useState<{
     imageUri: string;
-    imageType: 'cover' | 'backcover' | 'chapter';
+    imageType: "cover" | "backcover" | "chapter";
     chapterNumber?: number;
     title?: string;
   } | null>(null);
-  
+
   // Toast notifications
-  const { toasts, addToast, removeToast, successWithAction, error: toastError } = useToast();
+  const {
+    toasts,
+    addToast,
+    removeToast,
+    successWithAction,
+    error: toastError,
+  } = useToast();
 
   // Load story data
   const loadStoryData = useCallback(async () => {
@@ -101,20 +87,20 @@ export default function StoryEditPage() {
     try {
       setLoading(true);
       const response = await fetch(`/api/stories/${storyId}/edit`);
-      
+
       if (!response.ok) {
-        throw new Error(tStoryEditPage('errors.failedToLoadStoryData'));
+        throw new Error(tStoryEditPage("errors.failedToLoadStoryData"));
       }
 
       const data: ApiResponse = await response.json();
       if (data.success) {
         setStoryData(data);
       } else {
-        throw new Error(tStoryEditPage('errors.failedToLoadStory'));
+        throw new Error(tStoryEditPage("errors.failedToLoadStory"));
       }
     } catch (error) {
-      console.error(tStoryEditPage('logging.errorLoadingStory'), error);
-      addToast(tStoryEditPage('errors.failedToLoadStoryDataToast'), 'error');
+      console.error(tStoryEditPage("logging.errorLoadingStory"), error);
+      addToast(tStoryEditPage("errors.failedToLoadStoryDataToast"), "error");
     } finally {
       setLoading(false);
     }
@@ -127,31 +113,31 @@ export default function StoryEditPage() {
     try {
       setSaving(true);
       const response = await fetch(`/api/stories/${storyId}/edit`, {
-        method: 'PATCH',
+        method: "PATCH",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
         body: JSON.stringify(updates),
       });
 
       if (!response.ok) {
-        throw new Error(tStoryEditPage('errors.failedToUpdateStoryInfo'));
+        throw new Error(tStoryEditPage("errors.failedToUpdateStoryInfo"));
       }
 
       const result = await response.json();
-      
+
       if (result.success) {
         // Update local state
-        setStoryData(prev => {
+        setStoryData((prev) => {
           if (!prev) return prev;
           return { ...prev, story: result.story };
         });
 
-        addToast(tStoryEditPage('success.storyInfoUpdated'), 'success');
+        addToast(tStoryEditPage("success.storyInfoUpdated"), "success");
       }
     } catch (error) {
-      console.error(tStoryEditPage('logging.errorUpdatingStoryInfo'), error);
-      addToast(tStoryEditPage('errors.failedToUpdateStoryInfo'), 'error');
+      console.error(tStoryEditPage("logging.errorUpdatingStoryInfo"), error);
+      addToast(tStoryEditPage("errors.failedToUpdateStoryInfo"), "error");
     } finally {
       setSaving(false);
     }
@@ -167,23 +153,23 @@ export default function StoryEditPage() {
   const handleDuplicate = async () => {
     try {
       const resp = await fetch(`/api/my-stories/${storyId}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-  // Do not send locale when duplicating; language remains original.
-  body: JSON.stringify({ action: 'duplicate' }),
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        // Do not send locale when duplicating; language remains original.
+        body: JSON.stringify({ action: "duplicate" }),
       });
       if (!resp.ok) throw new Error(`Duplicate failed: ${resp.status}`);
       const data = await resp.json();
       const newId = data?.story?.storyId || data?.storyId;
       const link = `/${locale}/stories/read/${newId}`;
       successWithAction(
-        tMyStories('duplicate.success'),
-        tActions('open'),
-        link
+        tMyStories("duplicate.success"),
+        tActions("open"),
+        link,
       );
     } catch (e) {
-      console.error('Error duplicating story:', e);
-      toastError(tActions('tryAgain'));
+      console.error("Error duplicating story:", e);
+      toastError(tActions("tryAgain"));
     }
   };
 
@@ -194,18 +180,23 @@ export default function StoryEditPage() {
       return;
     } else {
       // Navigate to chapter edit page
-      router.push(`/${locale}/stories/edit/${storyId}/chapter/${chapterNumber}`);
+      router.push(
+        `/${locale}/stories/edit/${storyId}/chapter/${chapterNumber}`,
+      );
     }
   };
 
   // Handle AI edit success
   const handleAIEditSuccess = async (updatedData: Record<string, unknown>) => {
-    console.log(tStoryEditPage('logging.aiEditSuccessUpdatedData'), updatedData);
-    
+    console.log(
+      tStoryEditPage("logging.aiEditSuccessUpdatedData"),
+      updatedData,
+    );
+
     // Handle full story edit
-    if (updatedData.scope === 'story') {
+    if (updatedData.scope === "story") {
       const storyEditData = updatedData as {
-        scope: 'story';
+        scope: "story";
         updatedChapters: Array<{
           chapterNumber: number;
           success: boolean;
@@ -216,58 +207,62 @@ export default function StoryEditPage() {
         failedEdits: number;
         autoSaved: boolean;
       };
-      
+
       // Reload story data to get all updated chapters
       await loadStoryData();
-      
+
       // Show detailed results
       const successCount = storyEditData.successfulEdits;
       const failCount = storyEditData.failedEdits;
-      
+
       if (failCount > 0) {
         const failedChapters = storyEditData.updatedChapters
-          .filter(ch => !ch.success)
-          .map(ch => ch.chapterNumber)
-          .join(', ');
-        
+          .filter((ch) => !ch.success)
+          .map((ch) => ch.chapterNumber)
+          .join(", ");
+
         addToast(
-          tStoryEditPage('chapterUpdates.chaptersUpdatedSuccessfully', {
+          tStoryEditPage("chapterUpdates.chaptersUpdatedSuccessfully", {
             successCount: successCount.toString(),
-            failedChapters: failedChapters
+            failedChapters: failedChapters,
           }),
-          'warning'
+          "warning",
         );
       } else {
         addToast(
-          tStoryEditPage('chapterUpdates.allChaptersUpdated', {
-            successCount: successCount.toString()
+          tStoryEditPage("chapterUpdates.allChaptersUpdated", {
+            successCount: successCount.toString(),
           }),
-          'success'
+          "success",
         );
       }
     } else if (updatedData.updatedHtml && updatedData.chaptersUpdated) {
       // For story-wide edits (legacy format), reload data to get all updated chapters
       await loadStoryData();
-      addToast(tStoryEditPage('success.storyUpdated'), 'success');
+      addToast(tStoryEditPage("success.storyUpdated"), "success");
     } else if (updatedData.updatedHtml) {
       // For single chapter edits, we could update directly but currently
       // this page doesn't show individual chapter content, so reload
       await loadStoryData();
-      addToast(tStoryEditPage('success.chapterUpdated'), 'success');
+      addToast(tStoryEditPage("success.chapterUpdated"), "success");
     } else {
       // Fallback: reload story data to get the latest changes
       await loadStoryData();
-      addToast(tStoryEditPage('success.contentUpdated'), 'success');
+      addToast(tStoryEditPage("success.contentUpdated"), "success");
     }
   };
 
   // Handle AI edit optimistic update
-  const handleAIEditOptimisticUpdate = (_updatedData: Record<string, unknown>) => { // eslint-disable-line @typescript-eslint/no-unused-vars
+  const handleAIEditOptimisticUpdate = (
+    _updatedData: Record<string, unknown>,
+  ) => {
+    // eslint-disable-line @typescript-eslint/no-unused-vars
     // This could be used for optimistic UI updates if needed
   };
 
   // Handle AI edit revert
-  const handleAIEditRevertUpdate = (_originalData: Record<string, unknown>) => { // eslint-disable-line @typescript-eslint/no-unused-vars
+  const handleAIEditRevertUpdate = (_originalData: Record<string, unknown>) => {
+    // eslint-disable-line @typescript-eslint/no-unused-vars
     // This could be used to revert optimistic updates
   };
 
@@ -282,7 +277,7 @@ export default function StoryEditPage() {
       <div className="min-h-screen bg-base-100 flex items-center justify-center">
         <div className="text-center">
           <div className="loading loading-spinner loading-lg text-primary mb-4"></div>
-          <p className="text-lg font-medium">{tLoading('default')}</p>
+          <p className="text-lg font-medium">{tLoading("default")}</p>
         </div>
       </div>
     );
@@ -293,15 +288,19 @@ export default function StoryEditPage() {
     return (
       <div className="min-h-screen bg-base-100 flex items-center justify-center">
         <div className="text-center max-w-md">
-          <div className="text-6xl mb-4">{tStoryEditPage('errors.errorEmoji')}</div>
-          <h1 className="text-2xl font-bold mb-2">{tErrors('generic')}</h1>
-          <p className="text-base-content/70 mb-6">{tStoryEditPage('errors.failedToLoadStoryData')}</p>
+          <div className="text-6xl mb-4">
+            {tStoryEditPage("errors.errorEmoji")}
+          </div>
+          <h1 className="text-2xl font-bold mb-2">{tErrors("generic")}</h1>
+          <p className="text-base-content/70 mb-6">
+            {tStoryEditPage("errors.failedToLoadStoryData")}
+          </p>
           <button
             onClick={() => router.push(`/${locale}/stories`)}
             className="btn btn-primary"
           >
             <FiArrowLeft className="w-4 h-4 mr-2" />
-            {tActions('goBack')}
+            {tActions("goBack")}
           </button>
         </div>
       </div>
@@ -314,14 +313,13 @@ export default function StoryEditPage() {
       <div className="bg-base-200 border-b border-base-300 px-4 py-3">
         <div className="max-w-7xl mx-auto flex items-center justify-between">
           <div className="flex items-center gap-3">
-            <button
-              onClick={handleGoBack}
-              className="btn btn-ghost btn-sm"
-            >
+            <button onClick={handleGoBack} className="btn btn-ghost btn-sm">
               <FiArrowLeft className="w-4 h-4" />
-              <span className="hidden sm:inline ml-2">{tActions('goBack')}</span>
+              <span className="hidden sm:inline ml-2">
+                {tActions("goBack")}
+              </span>
             </button>
-            
+
             <h1 className="text-xl font-bold">{storyData.story.title}</h1>
           </div>
 
@@ -332,12 +330,11 @@ export default function StoryEditPage() {
               currentChapter={0}
               onChapterChange={handleChapterChange}
             />
-            <button
-              onClick={handleDuplicate}
-              className="btn btn-ghost btn-sm"
-            >
+            <button onClick={handleDuplicate} className="btn btn-ghost btn-sm">
               <FiCopy className="w-4 h-4" />
-              <span className="hidden sm:inline ml-2">{tActions('duplicate')}</span>
+              <span className="hidden sm:inline ml-2">
+                {tActions("duplicate")}
+              </span>
             </button>
           </div>
         </div>
@@ -355,8 +352,8 @@ export default function StoryEditPage() {
               if (storyData.story.coverUri) {
                 setSelectedImageData({
                   imageUri: storyData.story.coverUri,
-                  imageType: 'cover',
-                  title: tStoryEditPage('imageTypes.frontCover')
+                  imageType: "cover",
+                  title: tStoryEditPage("imageTypes.frontCover"),
                 });
                 setShowAIImageEditor(true);
               }
@@ -365,16 +362,14 @@ export default function StoryEditPage() {
               if (storyData.story.backcoverUri) {
                 setSelectedImageData({
                   imageUri: storyData.story.backcoverUri,
-                  imageType: 'backcover',
-                  title: tStoryEditPage('imageTypes.backCover')
+                  imageType: "backcover",
+                  title: tStoryEditPage("imageTypes.backCover"),
                 });
                 setShowAIImageEditor(true);
               }
             }}
             isLoading={saving}
           />
-
-          
 
           {/* AI Text Editor Modal */}
           <AITextStoryEditor
@@ -386,9 +381,9 @@ export default function StoryEditPage() {
               coverUri: storyData.story.coverUri,
               backcoverUri: storyData.story.backcoverUri,
               targetAudience: storyData.story.targetAudience,
-              graphicalStyle: storyData.story.graphicalStyle
+              graphicalStyle: storyData.story.graphicalStyle,
             }}
-            chapters={storyData.chapters.map(chapter => ({
+            chapters={storyData.chapters.map((chapter) => ({
               id: chapter.id,
               chapterNumber: chapter.chapterNumber,
               title: chapter.title,
@@ -396,7 +391,7 @@ export default function StoryEditPage() {
               imageThumbnailUri: chapter.imageThumbnailUri,
               htmlContent: chapter.htmlContent,
               audioUri: chapter.audioUri,
-              version: chapter.version
+              version: chapter.version,
             }))}
             onEditSuccess={handleAIEditSuccess}
             onOptimisticUpdate={handleAIEditOptimisticUpdate}
@@ -417,7 +412,7 @@ export default function StoryEditPage() {
                 coverUri: storyData.story.coverUri,
                 backcoverUri: storyData.story.backcoverUri,
                 targetAudience: storyData.story.targetAudience,
-                graphicalStyle: storyData.story.graphicalStyle
+                graphicalStyle: storyData.story.graphicalStyle,
               }}
               imageData={selectedImageData}
               onImageEditSuccess={handleAIEditSuccess}
@@ -446,4 +441,3 @@ export default function StoryEditPage() {
     </div>
   );
 }
-

--- a/src/types/chapter.ts
+++ b/src/types/chapter.ts
@@ -1,0 +1,19 @@
+export interface ApiChapter {
+  id: string;
+  chapterNumber: number;
+  title: string;
+  imageUri: string | null;
+  imageThumbnailUri: string | null;
+  htmlContent: string;
+  audioUri: string | null;
+  version: number;
+  hasNextVersion: boolean;
+  hasPreviousVersion: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Chapter extends Omit<ApiChapter, "createdAt" | "updatedAt"> {
+  createdAt: Date;
+  updatedAt: Date;
+}

--- a/src/utils/chapterConversion.test.ts
+++ b/src/utils/chapterConversion.test.ts
@@ -1,0 +1,32 @@
+import {
+  convertApiChaptersToChapters,
+  type ApiChapter,
+} from "@/utils/chapterConversion";
+
+describe("convertApiChaptersToChapters", () => {
+  it("converts date strings to Date objects", () => {
+    const apiChapters: ApiChapter[] = [
+      {
+        id: "1",
+        chapterNumber: 1,
+        title: "Test",
+        imageUri: null,
+        imageThumbnailUri: null,
+        htmlContent: "<p>Hello</p>",
+        audioUri: null,
+        version: 1,
+        hasNextVersion: false,
+        hasPreviousVersion: false,
+        createdAt: "2024-06-17T12:34:56Z",
+        updatedAt: "2024-06-18T12:34:56Z",
+      },
+    ];
+
+    const chapters = convertApiChaptersToChapters(apiChapters);
+
+    expect(chapters).toHaveLength(1);
+    expect(chapters[0].createdAt).toBeInstanceOf(Date);
+    expect(chapters[0].updatedAt).toBeInstanceOf(Date);
+    expect(chapters[0].title).toBe("Test");
+  });
+});

--- a/src/utils/chapterConversion.ts
+++ b/src/utils/chapterConversion.ts
@@ -1,0 +1,13 @@
+import type { ApiChapter, Chapter } from "@/types/chapter";
+
+export const convertApiChaptersToChapters = (
+  apiChapters: ApiChapter[],
+): Chapter[] => {
+  return apiChapters.map((chapter) => ({
+    ...chapter,
+    createdAt: new Date(chapter.createdAt),
+    updatedAt: new Date(chapter.updatedAt),
+  }));
+};
+
+export type { ApiChapter, Chapter };


### PR DESCRIPTION
## Summary
- add shared ApiChapter and Chapter types
- centralize chapter conversion to `convertApiChaptersToChapters`
- reuse chapter conversion in story edit pages

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0607e806c8328906c5734f3b2d0d8