### PR TITLE
docs: refresh agent guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,24 +1,81 @@
 # Mythoria Web App – Agent Guide
 
-## Dev environment tips
-- Node.js 22+ and npm are required.
-- Install dependencies with `npm install`.
-- Create a `.env.local` file with the required secrets (see `README.md`).
-- Apply database migrations using `npm run db:push`.
-- Start the development server with `npm run dev`.
+## Purpose & Scope
+This document is the single source of truth for agents working on the Mythoria web application. It describes how to set up the project, which quality checks must run before submitting work, and how to keep configuration and documentation in sync with the codebase.
 
-## Testing instructions
-- Lint: `npm run lint`
-- Type check: `npm run typecheck`
-- Unit tests: `npm test`
+## Technology Snapshot
+- **Framework**: Next.js 15 (App Router, standalone output)
+- **Language**: TypeScript 5 with strict compiler settings
+- **Runtime**: Node.js 22+ (enforced through `package.json` engines and Dockerfile)
+- **UI**: React 19, Tailwind CSS + DaisyUI, Next PWA integration
+- **Internationalization**: `next-intl` with locale-specific route segments and JSON message bundles
+- **Data Layer**: PostgreSQL via Drizzle ORM (schema in `src/db/schema`, SQL artifacts under `drizzle/`)
+- **Testing & QA**: ESLint, TypeScript, Jest, Playwright, i18n parity scripts, Prettier
 
-## PR instructions
-- Use conventional commit messages.
-- Run lint, typecheck, and tests before committing.
-- Format code when needed with `npm run format:fix`.
+## Repository Layout Highlights
+- `src/app` – App Router entry points (server components by default, locale-prefixed routes, offline fallbacks)
+- `src/components` – Reusable UI building blocks (`'use client'` when interactivity is required)
+- `src/lib` – Server-side utilities (authentication, analytics, workflow clients, pub/sub helpers, manifest helpers)
+- `src/utils` – Pure utility helpers and co-located unit tests
+- `src/db` – Drizzle schema, services, and database scripts (migrate/reset/seed)
+- `src/messages` – Locale-specific translation bundles (JSON namespaces per feature)
+- `src/types` – Shared TypeScript types and the auto-generated `translation-keys.d.ts`
+- `scripts` – Tooling for env validation, i18n maintenance, and deployment support
+- `docs` – High-level product and architecture documentation
 
-## Coding style
-- 2 spaces for indentation, single quotes, semicolons, and trailing commas.
-- Place external imports before internal `@/` imports.
-- Prefer arrow functions for callbacks and `async/await` for asynchronous code.
-- Export shared types from `src/types`.
+## Local Environment Setup
+1. Use Node.js 22 or newer (`nvm use 22` if needed) and install dependencies with `npm install`.
+2. Copy environment variables into `.env.local` (see **Environment Variables** below) and keep them aligned with `env.manifest.ts`.
+3. Validate the configuration by running `npm run check:env`; resolve all reported mismatches.
+4. Start the development server with `npm run dev` (Turbopack enabled). The app runs at `http://localhost:3000` by default.
+5. When adding new dependencies, prefer `npm install` (package-lock is committed).
+
+## Environment Variables
+- `env.manifest.ts` is the canonical manifest that describes every variable, its scopes (dev/build/runtime/public), and whether it is a secret. Update this file whenever environment requirements change.
+- Sync `.env.local`, deployment manifests (e.g., `cloudbuild.yaml`), and Docker build args with the manifest. Use `npm run check:env` after every change to confirm parity.
+- `NEXT_PUBLIC_SUPPORTED_LOCALES` controls the locales exposed by the router. Defaults come from `src/config/locales.ts` but should remain consistent across runtime and build environments.
+- Keep secrets out of the repository. Non-public values belong in Secret Manager or your local `.env.local` only.
+
+## Database Workflow (Drizzle ORM)
+- Schema definitions live in `src/db/schema`. Update `schema/index.ts` to re-export new tables/enums so Drizzle migrations and services can import them.
+- Generate SQL migrations with `npm run db:generate` and commit the resulting files under `drizzle/`.
+- Apply migrations locally with `npm run db:migrate` (uses `.env.local` credentials) or `npm run db:push` for schema synchronization.
+- `npm run db:reset` drops application tables and enums; `npm run db:setup` performs a reset followed by a push. Use cautiously.
+- `npm run db:studio` launches the Drizzle Studio inspector. `npm run db:seed` is currently a no-op placeholder; keep it updated if a real seed workflow is introduced.
+- Services under `src/db/services` should be covered by Jest tests co-located in the same directory.
+
+## Development & Quality Checklist
+Run these commands before committing or opening a PR:
+- `npm run lint` – ESLint (flat config via `eslint.config.mjs`)
+- `npm run typecheck` – TypeScript `tsc --noEmit`
+- `npm run test` – Jest unit tests (includes React Testing Library and server-side utilities)
+- `npm run format` – Prettier validation (use `npm run format:fix` if formatting issues are reported)
+- `npm run i18n:parity` – Ensures locale bundles remain aligned with `en-US`
+- `npm run i18n:keys` – Regenerates `src/types/translation-keys.d.ts` after modifying source translations
+- `npm run test:e2e` – Playwright tests (requires `npm run dev` running separately; auth state auto-refreshes unless `SKIP_AUTH_SETUP=1`)
+- `npm run test:e2e:anon` – Anonymous Playwright smoke suite for missing translation detection (sets `SKIP_AUTH_SETUP=1` automatically)
+- `npm run check:env` – Validate environment parity when env-related files change
+
+Only run the localization, env, or database commands when you touch the corresponding areas, but ensure CI-critical checks (`lint`, `typecheck`, `test`) are green for every change set.
+
+## Localization Workflow
+- `src/messages/en-US` is the source-of-truth locale. Mirror file names across every locale directory. HTML fragments (e.g., legal pages) also require parity.
+- Use `useTranslations`/`getTranslations` from `next-intl` with typed keys from `TranslationKey` to avoid runtime typos.
+- After editing translations:
+  - Run `npm run i18n:keys` to refresh the generated union type.
+  - Run `npm run i18n:parity` to detect missing or extra keys across locales.
+  - Optionally prune unused keys with `npm run i18n:prune:pt-PT:common` (or adjust the locale/namespace parameters as needed).
+- Keep the allowlist in `src/messages/i18n-keep.json` updated if certain keys must never be pruned.
+
+## Playwright & PWA Notes
+- Playwright stores auth state in `tests/playwright/.auth/user.json`. Force regeneration with `REFRESH_AUTH=1` if credentials expire. Anonymous suites bypass auth state by setting `SKIP_AUTH_SETUP=1`.
+- The application ships with a PWA offline fallback located at `/offline`. Middleware bypasses locale redirects for that route—preserve this behavior when adding new middleware logic.
+
+## Deployment
+- Production builds use `npm run build` (standalone output) followed by `npm run start` for local verification.
+- Google Cloud Run deployment is handled via `npm run deploy:production` (Cloud Build). Update Docker build args and environment substitutions alongside manifest changes.
+
+## PR & Commit Guidelines
+- Follow Conventional Commit messages (e.g., `feat: add X`, `fix: handle Y`).
+- Include updated tests and documentation for any user-facing or behavioral change.
+- Keep the working tree clean: run the commands above, stage intentional changes only, and ensure `git status` is clean before finishing.

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -1,11 +1,40 @@
 # Source Code – Agent Guide
 
-## React & TypeScript
-- Use functional components and hooks.
-- Avoid `any`; rely on strict TypeScript types.
-- Use the `@/` alias for internal imports.
-- Place reusable components under `src/components` and utilities under `src/utils`.
-- Export shared types from `src/types`.
+## Architectural Conventions
+- This project targets **Next.js App Router** semantics. Treat files in `src/app` as server components by default; add `'use client'` only where hooks, browser APIs, or interactive state are required.
+- Prefer typed data flows. Imports from `@/types` and `src/db/schema` provide canonical shapes; avoid `any` and keep runtime schemas in `zod` modules.
+- Leverage the `@/` path alias (configured in `tsconfig.json`) for internal imports to avoid brittle relative paths.
 
-## Testing
-- Add or update Jest tests for any significant logic in this directory.
+## Directory Guidelines
+- `src/app` – Route handlers, layouts, and metadata functions. Locale is the first dynamic segment (`[locale]`). Keep shared layout concerns (e.g., StickyHeader/Footer wiring, metadata loaders) here.
+- `src/components` – Client-facing UI widgets. Co-locate component-specific styles or helpers in subfolders when the surface grows (`ai-edit`, `image-editing-tab`, etc.). Components that require hooks must include `'use client'`.
+- `src/lib` – Server utilities and integrations (auth, analytics, workflows, Pub/Sub, manifest helpers). Keep React-free modules here; expose pure or server-side functions only.
+- `src/utils` – Pure helper functions (date formatting, enum normalization, storage utilities). Unit tests belong next to the implementation (`*.test.ts`).
+- `src/db` – Drizzle ORM schema, services, and scripting entry points (`migrate.ts`, `reset.ts`, `seed.ts`). Services should remain framework-agnostic and covered by Jest.
+- `src/messages` – `next-intl` translation bundles. Maintain parity across locales and regenerate typed keys (`npm run i18n:keys`) after changes.
+- `src/types` – Reusable TypeScript interfaces. `translation-keys.d.ts` is generated—do not edit manually.
+- `src/config` & `src/constants` – Keep configuration (locales, feature toggles) and static values separate from runtime logic.
+
+## React & Styling Patterns
+- Use functional components and hooks exclusively; no class components.
+- Tailwind CSS (with DaisyUI) powers styling. Favor composition via utility classes and avoid inline styles unless dynamic values are required.
+- Keep images served with `next/image` where possible. Remote sources must be allowlisted in `next.config.ts`.
+- Re-export commonly used UI primitives through index files to simplify imports when appropriate.
+
+## Internationalization
+- Access translations with `useTranslations`/`getTranslations`. Translation namespaces mirror file names inside `src/messages/<locale>`.
+- When adding strings, update **all** locale files and regenerate `TranslationKey` (`npm run i18n:keys`). Missing keys surface in CI via `npm run i18n:parity` and through anonymous Playwright smoke tests.
+- Middleware (`src/middleware.ts`) coordinates Clerk auth and locale routing. Preserve the `/offline` bypass when modifying middleware behavior.
+
+## Testing Expectations
+- Co-locate Jest unit tests with implementation files using the `.test.ts`/`.test.tsx` suffix.
+- UI behavior should be covered with React Testing Library or Playwright depending on scope. Complex server utilities (e.g., analytics, Pub/Sub) require deterministic tests with mocked dependencies.
+- Keep Playwright fixtures in `tests/playwright`. Authenticated flows rely on the shared storage state defined in `playwright.config.ts`.
+
+## Data & Services
+- When extending Drizzle models, update `src/db/schema/index.ts` exports and generate migrations (`npm run db:generate`). Services in `src/db/services` should expose typed helpers for app components and maintain parity with the database schema.
+- Cross-service integrations (workflow API, notification engine, Google Cloud) live under `src/lib`. Encapsulate external HTTP/SDK calls there to keep components declarative.
+
+## Performance & Accessibility
+- Prefer lazy data loading via Next.js streaming where available. Memoize expensive client computations with React hooks (`useMemo`, `useCallback`).
+- Uphold accessibility: provide descriptive alt text, ARIA attributes, and keyboard-friendly interactions. DaisyUI themes already offer baseline semantics—extend responsibly.

--- a/src/app/AGENTS.md
+++ b/src/app/AGENTS.md
@@ -1,0 +1,25 @@
+# App Router – Agent Guide
+
+## Routing & Layouts
+- Locale is the leading dynamic segment (`/[locale]/…`). Update `routing.locales` and `generateStaticParams` when introducing new locales so static generation works correctly.
+- `src/app/layout.tsx` wires global providers (Clerk, analytics, PWA meta). Preserve the header-derived locale detection and keep `<ClerkProvider>` at the top level.
+- `src/app/[locale]/layout.tsx` loads locale messages from `src/messages/<locale>`. When adjusting the loader, maintain the filesystem fallback to `en-US` to avoid build-time failures.
+- The offline experience lives in `src/app/offline`. Ensure the route remains a plain page (no locale prefix) because middleware bypasses i18n for `/offline`.
+
+## API Routes (`src/app/api`)
+- Implement endpoints with the App Router `route.ts` convention and return `NextResponse`. Avoid using legacy `pages/api` patterns.
+- Keep routes resilient at build time. Guard database or network calls with the `NEXT_PHASE` checks already used in sitemap generation to prevent errors during static analysis.
+- Validate Clerk authentication or locale expectations in middleware-friendly ways (e.g., rely on request headers added by `src/middleware.ts`).
+
+## Styling & Assets
+- Global Tailwind customizations live in `src/app/[locale]/globals.css`. Reuse utility classes; only add new global styles when multiple components benefit.
+- Static metadata assets (sitemaps, manifest, offline page) reside directly under `src/app`. Keep them free of client-only APIs so they can execute during builds.
+
+## Data Fetching & Performance
+- Prefer server components for data fetching and pass serialized data to client components for interactivity.
+- Memoize expensive client logic (e.g., TypeAnimation sequences) and provide safe fallbacks when translations are missing.
+- When reading from the filesystem (messages, manifests), catch parse errors and log helpful warnings rather than letting the request crash.
+
+## Testing & QA
+- Cover complex route handlers with Jest (using mocked Next `Request`/`Response` objects) or Playwright integration tests when end-to-end behavior matters.
+- Sitemap and feed routes should have regression tests that exercise both build-time and runtime branches when practical.

--- a/src/db/AGENTS.md
+++ b/src/db/AGENTS.md
@@ -1,0 +1,20 @@
+# Database Layer – Agent Guide
+
+## Schema Maintenance
+- Domain schemas live in `src/db/schema`. Group related tables/enums by feature (stories, payments, credits, etc.) and re-export them from `schema/index.ts`.
+- Generate SQL migrations with `npm run db:generate` after changing the schema. Commit the generated files under `drizzle/` to keep CI and deployments reproducible.
+- Keep enum or helper definitions (`enums.ts`) aligned with any TypeScript counterparts in `src/types`.
+
+## Runtime Access
+- `src/db/index.ts` initializes Drizzle lazily using the shared pool from `@/lib/database-config`. Reuse this entry point; do not create ad-hoc `Pool` instances in feature code.
+- Respect the build-time guard (`NEXT_PHASE`) so static generation does not hit the database. When adding new runtime modules, check `process.env.NEXT_PHASE` and provide safe fallbacks similar to the existing pattern.
+
+## Services & Testing
+- Business logic that reads/writes data belongs in `src/db/services`. Expose small, typed functions that hide raw SQL details from the rest of the app.
+- Co-locate Jest specs (see `*.test.ts`) for every service to ensure queries remain stable as the schema evolves.
+- Prefer Drizzle query helpers over raw SQL. If raw SQL is unavoidable, encapsulate it in a service and document the reasons in-code.
+
+## Tooling Scripts
+- `migrate.ts`, `reset.ts`, and `seed.ts` are entry points for CLI workflows invoked via npm scripts. Keep them idempotent and environment-aware (they load `.env.local`).
+- `db:seed` is currently a no-op placeholder. Update both the script and this documentation if a real seed routine is introduced.
+- `db:setup` (reset + push) is destructive—never run it in shared environments without confirmation.

--- a/src/messages/AGENTS.md
+++ b/src/messages/AGENTS.md
@@ -1,0 +1,18 @@
+# Messages & Localization – Agent Guide
+
+## Directory Structure
+- Each locale (`en-US`, `pt-PT`, `es-ES`, `fr-FR`, …) mirrors the same set of JSON (and occasional HTML) files. File names double as translation namespaces (e.g., `HomePage.json` → `HomePage` namespace).
+- Treat `en-US` as the canonical source of truth. Add or rename keys there first, then propagate to every locale directory.
+- Keep non-JSON artifacts (such as `termsAndConditions.html`) in sync across locales; middleware expects parity when rendering legal pages.
+
+## Workflow
+1. Update the relevant `en-US` file(s).
+2. Copy the structure to the target locales, marking untranslated entries with TODO comments or fallback strings.
+3. Run `npm run i18n:keys` to regenerate `src/types/translation-keys.d.ts`.
+4. Run `npm run i18n:parity` to confirm no locale is missing or carrying extra keys.
+5. Use `npm run i18n:prune:pt-PT:common` (or adjust arguments) to clean unused keys when removing strings. Add prefixes to `i18n-keep.json` if you must keep specific keys.
+
+## Usage Guidelines
+- Access translations through `next-intl` helpers (`useTranslations`, `getTranslations`). Avoid hardcoding strings in components.
+- Store long-form rich text (markdown/HTML) in dedicated files to keep JSON manageable, as already done for legal documents.
+- Never edit `src/types/translation-keys.d.ts` manually—it is generated.


### PR DESCRIPTION
## Summary
- rewrite the root agent guide with up-to-date tooling, quality gates, and localization workflow details
- expand the source-level guide to document directory conventions, testing expectations, and accessibility standards
- add dedicated agent guides for the app router, database layer, and localization bundles to capture folder-specific practices

## Testing
- npm run lint
- npm run typecheck
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c87de702c08328bb1b109918fb0f3d