### PR TITLE
test: expand P0 credits and audiobook route coverage

### DIFF
--- a/src/app/api/share/[token]/route.test.ts
+++ b/src/app/api/share/[token]/route.test.ts
@@ -1,0 +1,98 @@
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (data: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => data,
+    }),
+  },
+}));
+
+const authMock = jest.fn();
+const currentUserMock = jest.fn();
+
+jest.mock('@clerk/nextjs/server', () => ({
+  auth: () => authMock(),
+  currentUser: () => currentUserMock(),
+}));
+
+const limitMock = jest.fn();
+const whereMock = jest.fn(() => ({ limit: limitMock }));
+const leftJoinMock: jest.Mock = jest.fn();
+leftJoinMock.mockImplementation(() => ({ leftJoin: leftJoinMock, where: whereMock }));
+const fromMock = jest.fn(() => ({ leftJoin: leftJoinMock, where: whereMock }));
+const selectMock = jest.fn(() => ({ from: fromMock }));
+
+jest.mock('@/db', () => ({
+  db: {
+    select: () => selectMock(),
+    insert: jest.fn(() => ({ values: jest.fn() })),
+  },
+}));
+
+jest.mock('@/db/schema', () => ({
+  stories: {
+    storyId: 'storyId',
+    title: 'title',
+    synopsis: 'synopsis',
+    audiobookUri: 'audiobookUri',
+    targetAudience: 'targetAudience',
+    graphicalStyle: 'graphicalStyle',
+    coverUri: 'coverUri',
+    createdAt: 'createdAt',
+    authorId: 'authorId',
+  },
+  shareLinks: {
+    id: 'id',
+    storyId: 'storyId',
+    accessLevel: 'accessLevel',
+    expiresAt: 'expiresAt',
+    revoked: 'revoked',
+  },
+  storyCollaborators: { storyId: 'storyId', userId: 'userId' },
+  authors: { authorId: 'authorId', displayName: 'displayName', clerkUserId: 'clerkUserId' },
+}));
+
+jest.mock('drizzle-orm', () => ({ eq: jest.fn(() => ({})), and: jest.fn(() => ({})) }));
+jest.mock('@/db/services', () => ({ authorService: { syncUserOnSignIn: jest.fn() } }));
+
+import { GET } from './route';
+
+describe('GET /api/share/[token]', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    currentUserMock.mockResolvedValue(null);
+  });
+
+  it('returns auth-required payload for edit links when user is anonymous', async () => {
+    authMock.mockResolvedValue({ userId: null });
+    limitMock.mockResolvedValueOnce([
+      {
+        storyId: 'story-1',
+        accessLevel: 'edit',
+        expiresAt: new Date(Date.now() + 60_000).toISOString(),
+        revoked: false,
+        story: { title: 'The Quest', synopsis: 'A brave quest' },
+        author: { displayName: 'Ada' },
+      },
+    ]);
+
+    const response = (await GET({ headers: { get: () => null } } as unknown as Request, {
+      params: Promise.resolve({ token: 'token-1' }),
+    })) as { status: number; json: () => Promise<unknown> };
+
+    const payload = (await response.json()) as {
+      success: boolean;
+      requiresAuth: boolean;
+      accessLevel: string;
+      storyPreview: { title: string; authorName: string };
+    };
+
+    expect(response.status).toBe(401);
+    expect(payload).toMatchObject({
+      success: false,
+      requiresAuth: true,
+      accessLevel: 'edit',
+      storyPreview: { title: 'The Quest', authorName: 'Ada' },
+    });
+  });
+});

--- a/src/app/api/stories/[storyId]/deduct-credits/route.test.ts
+++ b/src/app/api/stories/[storyId]/deduct-credits/route.test.ts
@@ -1,0 +1,153 @@
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (data: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => data,
+    }),
+  },
+}));
+
+const getCurrentAuthorMock = jest.fn();
+const calculateCreditsForFeaturesMock = jest.fn();
+const getAuthorCreditBalanceMock = jest.fn();
+const deductCreditsMock = jest.fn();
+
+jest.mock('@/lib/auth', () => ({
+  getCurrentAuthor: () => getCurrentAuthorMock(),
+}));
+
+jest.mock('@/db/services', () => ({
+  pricingService: {
+    calculateCreditsForFeatures: (...args: unknown[]) => calculateCreditsForFeaturesMock(...args),
+  },
+  creditService: {
+    getAuthorCreditBalance: (...args: unknown[]) => getAuthorCreditBalanceMock(...args),
+    deductCredits: (...args: unknown[]) => deductCreditsMock(...args),
+  },
+}));
+
+import type { NextRequest } from 'next/server';
+import { POST } from './route';
+
+function buildRequest(body: unknown): NextRequest {
+  return {
+    json: async () => body,
+  } as unknown as NextRequest;
+}
+
+describe('POST /api/stories/[storyId]/deduct-credits', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 402 and does not deduct when credits are insufficient', async () => {
+    getCurrentAuthorMock.mockResolvedValue({ authorId: 'author-1' });
+    calculateCreditsForFeaturesMock.mockResolvedValue({
+      total: 7,
+      breakdown: [{ serviceCode: 'eBookGeneration', credits: 7 }],
+    });
+    getAuthorCreditBalanceMock.mockResolvedValue(4);
+
+    const response = (await POST(
+      buildRequest({
+        storyId: 'story-99',
+        selectedFeatures: { ebook: true, printed: false, audiobook: false },
+      }),
+    )) as { status: number; json: () => Promise<unknown> };
+
+    await expect(response.json()).resolves.toEqual({
+      error: 'Insufficient credits',
+      required: 7,
+      available: 4,
+      shortfall: 3,
+    });
+    expect(response.status).toBe(402);
+    expect(deductCreditsMock).not.toHaveBeenCalled();
+  });
+
+  it('deducts each selected service and returns updated balance', async () => {
+    getCurrentAuthorMock.mockResolvedValue({ authorId: 'author-1' });
+    calculateCreditsForFeaturesMock.mockResolvedValue({
+      total: 10,
+      breakdown: [
+        { serviceCode: 'eBookGeneration', credits: 6 },
+        { serviceCode: 'audioBookGeneration', credits: 4 },
+      ],
+    });
+    getAuthorCreditBalanceMock
+      .mockResolvedValueOnce(30) // previous balance
+      .mockResolvedValueOnce(20); // updated balance
+
+    deductCreditsMock
+      .mockResolvedValueOnce({ creditId: 'tx-1' })
+      .mockResolvedValueOnce({ creditId: 'tx-2' });
+
+    const response = (await POST(
+      buildRequest({
+        storyId: 'story-99',
+        selectedFeatures: { ebook: true, printed: false, audiobook: true },
+      }),
+    )) as { status: number; json: () => Promise<unknown> };
+
+    const payload = (await response.json()) as {
+      success: boolean;
+      totalDeducted: number;
+      previousBalance: number;
+      newBalance: number;
+      transactions: Array<{ creditId: string; description: string }>;
+    };
+
+    expect(response.status).toBe(200);
+    expect(payload.success).toBe(true);
+    expect(payload.totalDeducted).toBe(10);
+    expect(payload.previousBalance).toBe(30);
+    expect(payload.newBalance).toBe(20);
+    expect(payload.transactions).toEqual([
+      { creditId: 'tx-1', description: 'Digital Book Generation' },
+      { creditId: 'tx-2', description: 'Audiobook Generation' },
+    ]);
+
+    expect(deductCreditsMock).toHaveBeenNthCalledWith(
+      1,
+      'author-1',
+      6,
+      'eBookGeneration',
+      'story-99',
+    );
+    expect(deductCreditsMock).toHaveBeenNthCalledWith(
+      2,
+      'author-1',
+      4,
+      'audioBookGeneration',
+      'story-99',
+    );
+  });
+
+  it('returns 500 when one deduction fails', async () => {
+    getCurrentAuthorMock.mockResolvedValue({ authorId: 'author-1' });
+    calculateCreditsForFeaturesMock.mockResolvedValue({
+      total: 12,
+      breakdown: [
+        { serviceCode: 'eBookGeneration', credits: 5 },
+        { serviceCode: 'printOrder', credits: 7 },
+      ],
+    });
+    getAuthorCreditBalanceMock.mockResolvedValue(100);
+    deductCreditsMock
+      .mockResolvedValueOnce({ creditId: 'tx-1' })
+      .mockRejectedValueOnce(new Error('db-write-failed'));
+
+    const response = (await POST(
+      buildRequest({
+        storyId: 'story-99',
+        selectedFeatures: { ebook: true, printed: true, audiobook: false },
+      }),
+    )) as { status: number; json: () => Promise<unknown> };
+
+    await expect(response.json()).resolves.toEqual({
+      error: 'Failed to deduct credits for Printed Book Order',
+    });
+    expect(response.status).toBe(500);
+    expect(deductCreditsMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/app/api/stories/[storyId]/generate-audiobook/route.test.ts
+++ b/src/app/api/stories/[storyId]/generate-audiobook/route.test.ts
@@ -1,0 +1,122 @@
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (data: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => data,
+    }),
+  },
+}));
+
+const getCurrentAuthorMock = jest.fn();
+const getStoryByIdMock = jest.fn();
+const getPricingByServiceCodeMock = jest.fn();
+const getAuthorCreditBalanceMock = jest.fn();
+const deductCreditsMock = jest.fn();
+const addCreditsMock = jest.fn();
+const updateStoryMock = jest.fn();
+const publishAudiobookRequestMock = jest.fn();
+
+jest.mock('@/lib/auth', () => ({
+  getCurrentAuthor: () => getCurrentAuthorMock(),
+}));
+
+jest.mock('@/db/services', () => ({
+  storyService: {
+    getStoryById: (...args: unknown[]) => getStoryByIdMock(...args),
+    updateStory: (...args: unknown[]) => updateStoryMock(...args),
+  },
+  pricingService: {
+    getPricingByServiceCode: (...args: unknown[]) => getPricingByServiceCodeMock(...args),
+  },
+  creditService: {
+    getAuthorCreditBalance: (...args: unknown[]) => getAuthorCreditBalanceMock(...args),
+    deductCredits: (...args: unknown[]) => deductCreditsMock(...args),
+    addCredits: (...args: unknown[]) => addCreditsMock(...args),
+  },
+}));
+
+jest.mock('@/lib/pubsub', () => ({
+  publishAudiobookRequest: (...args: unknown[]) => publishAudiobookRequestMock(...args),
+}));
+
+jest.mock('uuid', () => ({ v4: () => 'run-fixed-123' }));
+
+import type { NextRequest } from 'next/server';
+import { POST } from './route';
+
+function buildRequest(body: unknown): NextRequest {
+  return {
+    json: async () => body,
+  } as unknown as NextRequest;
+}
+
+describe('POST /api/stories/[storyId]/generate-audiobook', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 404 and does not deduct when story is not owned by the current author', async () => {
+    getCurrentAuthorMock.mockResolvedValue({ authorId: 'author-1' });
+    getStoryByIdMock.mockResolvedValue({ storyId: 'story-1', authorId: 'author-2', status: 'published' });
+
+    const response = (await POST(buildRequest({}), {
+      params: Promise.resolve({ storyId: 'story-1' }),
+    })) as { status: number; json: () => Promise<unknown> };
+
+    await expect(response.json()).resolves.toEqual({ error: 'Story not found or access denied' });
+    expect(response.status).toBe(404);
+    expect(deductCreditsMock).not.toHaveBeenCalled();
+    expect(publishAudiobookRequestMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 402 when balance is insufficient and does not queue workflow', async () => {
+    getCurrentAuthorMock.mockResolvedValue({ authorId: 'author-1' });
+    getStoryByIdMock.mockResolvedValue({ storyId: 'story-1', authorId: 'author-1', status: 'published' });
+    getPricingByServiceCodeMock.mockResolvedValue({ credits: 8 });
+    getAuthorCreditBalanceMock.mockResolvedValue(3);
+
+    const response = (await POST(buildRequest({ voice: 'coral' }), {
+      params: Promise.resolve({ storyId: 'story-1' }),
+    })) as { status: number; json: () => Promise<unknown> };
+
+    await expect(response.json()).resolves.toEqual({
+      error: 'Insufficient credits',
+      required: 8,
+      available: 3,
+      shortfall: 5,
+    });
+    expect(response.status).toBe(402);
+    expect(deductCreditsMock).not.toHaveBeenCalled();
+    expect(updateStoryMock).not.toHaveBeenCalled();
+    expect(publishAudiobookRequestMock).not.toHaveBeenCalled();
+  });
+
+  it('refunds credits and reverts story status when pubsub publish fails', async () => {
+    getCurrentAuthorMock.mockResolvedValue({ authorId: 'author-1' });
+    getStoryByIdMock.mockResolvedValue({ storyId: 'story-1', authorId: 'author-1', status: 'published' });
+    getPricingByServiceCodeMock.mockResolvedValue({ credits: 5 });
+    getAuthorCreditBalanceMock.mockResolvedValue(20);
+    deductCreditsMock.mockResolvedValue({});
+    updateStoryMock.mockResolvedValue({});
+    publishAudiobookRequestMock.mockRejectedValue(new Error('pubsub down'));
+
+    const response = (await POST(buildRequest({ voice: 'coral', includeBackgroundMusic: true }), {
+      params: Promise.resolve({ storyId: 'story-1' }),
+    })) as { status: number; json: () => Promise<unknown> };
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Failed to start audiobook generation workflow',
+    });
+
+    expect(deductCreditsMock).toHaveBeenCalledWith(
+      'author-1',
+      5,
+      'audioBookGeneration',
+      'story-1',
+    );
+    expect(updateStoryMock).toHaveBeenNthCalledWith(1, 'story-1', { audiobookStatus: 'generating' });
+    expect(updateStoryMock).toHaveBeenNthCalledWith(2, 'story-1', { audiobookStatus: null });
+    expect(addCreditsMock).toHaveBeenCalledWith('author-1', 5, 'refund');
+  });
+});


### PR DESCRIPTION
### Motivation
- Increase high-value P0 API coverage around credits and audiobook workflows to prevent regressions in billing, authorization, and rollback logic.
- Ensure route handlers are exercised end-to-end (handler logic + service interactions) while keeping external dependencies deterministic via mocking.

### Description
- Expanded the Jest integration tests for `POST /api/stories/[storyId]/deduct-credits` to cover insufficient-balance rejection (`402`), successful multi-service deductions with expected transactions and balances, and partial-deduction failure handling (`500`).
- Expanded the Jest integration tests for `POST /api/stories/[storyId]/generate-audiobook` to cover ownership enforcement (`404`), balance enforcement (`402` without side effects), and pubsub failure rollback that reverts story status and refunds credits (`500`).
- Added deterministic test scaffolding including a small `buildRequest` helper, mocks for auth, pricing/credit/story services, pubsub, and `uuid`, and a lightweight `NextResponse` mock so real route handler code paths run in tests.

### Testing
- Ran `npm install` and dependency postinstall hooks, which completed successfully.
- Ran `npm run lint` and `npm run typecheck`, both of which passed in this environment.
- Ran `npm run test` and the modified suites executed successfully with the new tests passing (all targeted test suites passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988d995a5d08328a39b362eb1f573d3)