### PR TITLE
fix: clarify story generation handoff

### DIFF
--- a/src/app/[locale]/tell-your-story/step-4/page.tsx
+++ b/src/app/[locale]/tell-your-story/step-4/page.tsx
@@ -370,7 +370,7 @@ function Step4Page() {
         has_additional_requests: !!additionalRequests.trim(),
         has_image_generation_instructions: !!imageGenerationInstructions.trim(),
         next_step: 5,
-        cta_label: tStoryStepsStep4('next'),
+        cta_key: 'next',
       }); // Navigate to next step after successful save
       if (editStoryId) {
         // In edit mode, pass the edit parameter to the next step

--- a/src/app/[locale]/tell-your-story/step-4/page.tsx
+++ b/src/app/[locale]/tell-your-story/step-4/page.tsx
@@ -355,7 +355,7 @@ function Step4Page() {
         throw new Error(tStoryStepsStep4('errors.saveFailed'));
       }
 
-      // Track step 4 completion
+      // Track step 4 completion and the step-5 handoff for funnel observability.
       trackStoryCreation.stepCompleted({
         step: 4,
         story_id: currentStoryId,
@@ -369,6 +369,8 @@ function Step4Page() {
         has_plot_description: !!plotDescription.trim(),
         has_additional_requests: !!additionalRequests.trim(),
         has_image_generation_instructions: !!imageGenerationInstructions.trim(),
+        next_step: 5,
+        cta_label: tStoryStepsStep4('next'),
       }); // Navigate to next step after successful save
       if (editStoryId) {
         // In edit mode, pass the edit parameter to the next step
@@ -1092,6 +1094,9 @@ function Step4Page() {
                   }
                   nextLabel={saving ? tStoryStepsStep4('saving') : tStoryStepsStep4('next')}
                 />
+                <p className="mt-3 text-right text-sm text-gray-600">
+                  {tStoryStepsStep4('generationReviewHint')}
+                </p>
               </div>
             </div>
           </div>

--- a/src/app/[locale]/tell-your-story/step-5/page.tsx
+++ b/src/app/[locale]/tell-your-story/step-5/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { SignedIn, SignedOut, RedirectToSignIn } from '@clerk/nextjs';
-import { useState, useEffect, Suspense } from 'react';
+import { useState, useEffect, Suspense, useRef } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { useLocale, useTranslations } from 'next-intl';
 import StepNavigation from '@/components/StepNavigation';
@@ -48,6 +48,7 @@ function Step5Page() {
   const [storyData, setStoryData] = useState<StoryData | null>(null);
   const [userCredits, setUserCredits] = useState<number>(0);
   const [ebookPricing, setEbookPricing] = useState<EbookPricing | null>(null);
+  const hasTrackedStepView = useRef(false);
 
   const loadStoryData = async (storyId: string) => {
     try {
@@ -102,6 +103,20 @@ function Step5Page() {
     );
   }, [currentStoryId]); // eslint-disable-line react-hooks/exhaustive-deps
 
+  useEffect(() => {
+    if (loading || !currentStoryId || !storyData || hasTrackedStepView.current) return;
+
+    hasTrackedStepView.current = true;
+    trackStoryCreation.stepViewed({
+      step: 5,
+      story_id: currentStoryId,
+      has_pricing: !!ebookPricing,
+      ebook_cost: ebookPricing?.cost,
+      user_credits: userCredits,
+      can_generate: !!ebookPricing && userCredits >= ebookPricing.cost,
+    });
+  }, [currentStoryId, ebookPricing, loading, storyData, userCredits]);
+
   const hasInsufficientCredits = () => {
     // If pricing isn't loaded yet, assume insufficient credits to prevent premature actions
     if (!ebookPricing) return true;
@@ -109,6 +124,16 @@ function Step5Page() {
   };
 
   const handleCompleteStory = async () => {
+    trackStoryCreation.generateClicked({
+      step: 5,
+      story_id: currentStoryId || undefined,
+      has_story_data: !!storyData,
+      has_pricing: !!ebookPricing,
+      ebook_cost: ebookPricing?.cost,
+      user_credits: userCredits,
+      can_generate: !!ebookPricing && userCredits >= ebookPricing.cost,
+    });
+
     if (!currentStoryId || !storyData || !ebookPricing) {
       setError(tStoryStepsStep5('storyDataNotAvailable'));
       return;

--- a/src/components/StepNavigation.test.tsx
+++ b/src/components/StepNavigation.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import StepNavigation from './StepNavigation';
+
+const pushMock = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: pushMock,
+  }),
+}));
+
+jest.mock('next-intl', () => ({
+  useTranslations: () => (key: string) =>
+    ({
+      next: 'Next',
+      prev: 'Previous',
+      finish: 'Finish',
+    })[key] ?? key,
+}));
+
+describe('StepNavigation', () => {
+  beforeEach(() => {
+    pushMock.mockClear();
+  });
+
+  it('uses an explicit nextLabel on the final handoff step instead of forcing the finish label', () => {
+    render(
+      <StepNavigation
+        currentStep={4}
+        totalSteps={5}
+        nextHref="/tell-your-story/step-5"
+        prevHref="/tell-your-story/step-3"
+        nextLabel="Review and generate"
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: /review and generate/i })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /finish/i })).not.toBeInTheDocument();
+  });
+
+  it('falls back to the finish label on the final step when no nextLabel is supplied', () => {
+    render(
+      <StepNavigation
+        currentStep={4}
+        totalSteps={5}
+        nextHref="/tell-your-story/step-5"
+        prevHref="/tell-your-story/step-3"
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: /finish/i })).toBeInTheDocument();
+  });
+
+  it('keeps the explicit nextLabel when onNext handles validation before navigation', async () => {
+    const onNext = jest.fn().mockResolvedValue(true);
+
+    render(
+      <StepNavigation
+        currentStep={4}
+        totalSteps={5}
+        nextHref="/tell-your-story/step-5"
+        prevHref="/tell-your-story/step-3"
+        onNext={onNext}
+        nextLabel="Review and generate"
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /review and generate/i }));
+
+    await waitFor(() => expect(onNext).toHaveBeenCalledTimes(1));
+    expect(pushMock).toHaveBeenCalledWith('/tell-your-story/step-5');
+  });
+});

--- a/src/components/StepNavigation.tsx
+++ b/src/components/StepNavigation.tsx
@@ -30,7 +30,11 @@ const StepNavigation = ({
   const router = useRouter();
   const tCommonStepNavigation = useTranslations('StepNavigation');
 
-  const resolvedNextLabel = nextLabel ?? tCommonStepNavigation('next');
+  const resolvedNextLabel =
+    nextLabel ??
+    (currentStep === totalSteps - 1
+      ? tCommonStepNavigation('finish')
+      : tCommonStepNavigation('next'));
   const resolvedPrevLabel = prevLabel ?? tCommonStepNavigation('prev');
   const handleNext = async () => {
     if (onNext) {
@@ -91,8 +95,7 @@ const StepNavigation = ({
             disabled={nextDisabled}
             className={`btn btn-primary btn-md md:btn-lg ${nextDisabled ? 'btn-disabled' : ''}`} // Responsive button size
           >
-            {currentStep === totalSteps - 1 ? tCommonStepNavigation('finish') : resolvedNextLabel}{' '}
-            {/* Shortened "Finish Story" */}
+            {resolvedNextLabel}{' '}
             <svg
               xmlns="http://www.w3.org/2000/svg"
               className="h-5 w-5 ml-1 md:ml-2"
@@ -111,8 +114,7 @@ const StepNavigation = ({
             className={`btn btn-primary btn-md md:btn-lg ${nextDisabled ? 'btn-disabled' : ''}`} // Responsive button size
             onClick={handleNext}
           >
-            {currentStep === totalSteps - 1 ? tCommonStepNavigation('finish') : resolvedNextLabel}{' '}
-            {/* Shortened "Finish Story" */}
+            {resolvedNextLabel}{' '}
             <svg
               xmlns="http://www.w3.org/2000/svg"
               className="h-5 w-5 ml-1 md:ml-2"
@@ -131,8 +133,7 @@ const StepNavigation = ({
             disabled={nextDisabled}
             className={`btn btn-primary btn-md md:btn-lg ${nextDisabled ? 'btn-disabled' : ''}`} // Responsive button size
           >
-            {currentStep === totalSteps - 1 ? tCommonStepNavigation('finish') : resolvedNextLabel}{' '}
-            {/* Shortened "Finish Story" */}
+            {resolvedNextLabel}{' '}
             <svg
               xmlns="http://www.w3.org/2000/svg"
               className="h-5 w-5 ml-1 md:ml-2"

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -17,6 +17,8 @@ export type AnalyticsEvent =
   | 'logout'
   | 'story_creation_started'
   | 'story_creation_step_completed'
+  | 'story_creation_step_viewed'
+  | 'story_creation_generate_clicked'
   | 'story_generation_requested'
   | 'paid_action'
   | 'purchase';
@@ -168,6 +170,17 @@ export const trackStoryCreation = {
       ...params,
       step: params.step,
     });
+  },
+
+  stepViewed: (params: StoryEventParams = {}) => {
+    trackEvent('story_creation_step_viewed', {
+      ...params,
+      step: params.step,
+    });
+  },
+
+  generateClicked: (params: StoryEventParams = {}) => {
+    trackEvent('story_creation_generate_clicked', params);
   },
 
   generationRequested: (params: StoryEventParams = {}) => {

--- a/src/messages/de-DE/StorySteps.json
+++ b/src/messages/de-DE/StorySteps.json
@@ -382,7 +382,8 @@
         "loadFailed": "Geschichtsinformationen konnten nicht geladen werden. Bitte versuch es erneut."
       },
       "saving": "Wird gespeichert...",
-      "next": "Weiter"
+      "next": "Prüfen und generieren",
+      "generationReviewHint": "Im nächsten Schritt kannst du Credits prüfen und die Generierung starten. Es wird noch nichts generiert."
     },
     "step5": {
       "heading": "Kapitel 5 – Das Finale",

--- a/src/messages/en-US/StorySteps.json
+++ b/src/messages/en-US/StorySteps.json
@@ -382,7 +382,8 @@
         "loadFailed": "Failed to load story information. Please try again."
       },
       "saving": "Saving...",
-      "next": "Next"
+      "next": "Review and generate",
+      "generationReviewHint": "On the next step you can review credits and start generation. Nothing will be generated yet."
     },
     "step5": {
       "heading": "Chapter 5 - The Finale",

--- a/src/messages/es-ES/StorySteps.json
+++ b/src/messages/es-ES/StorySteps.json
@@ -382,7 +382,8 @@
         "loadFailed": "No se pudo cargar la información de la historia. Inténtalo de nuevo."
       },
       "saving": "Guardando...",
-      "next": "Siguiente"
+      "next": "Revisar y generar",
+      "generationReviewHint": "En el siguiente paso podrás revisar los créditos e iniciar la generación. Todavía no se generará nada."
     },
     "step5": {
       "heading": "Capítulo 5 - El final",

--- a/src/messages/fr-FR/StorySteps.json
+++ b/src/messages/fr-FR/StorySteps.json
@@ -382,7 +382,8 @@
         "loadFailed": "Échec du chargement des informations de l’histoire. Veuillez réessayer."
       },
       "saving": "Enregistrement...",
-      "next": "Suivant"
+      "next": "Vérifier et générer",
+      "generationReviewHint": "À l’étape suivante, vous pourrez vérifier les crédits et lancer la génération. Rien ne sera encore généré."
     },
     "step5": {
       "heading": "Chapitre 5 - Le final",

--- a/src/messages/pt-PT/StorySteps.json
+++ b/src/messages/pt-PT/StorySteps.json
@@ -382,7 +382,8 @@
         "loadFailed": "Falha ao carregar informações da história. Por favor, tente novamente."
       },
       "saving": "A guardar...",
-      "next": "Próximo"
+      "next": "Rever e gerar",
+      "generationReviewHint": "No próximo passo poderá rever os créditos e iniciar a geração. Nada será gerado ainda."
     },
     "step5": {
       "heading": "Capítulo 5 - O Final",


### PR DESCRIPTION
## Summary
- Respect explicit `nextLabel` in `StepNavigation` so the step 4 → step 5 handoff no longer renders as the generic finish action.
- Clarify the step 4 CTA/copy across locales: users now continue to “review and generate”, with helper copy that nothing is generated yet.
- Add minimal funnel analytics to separate step 4 save → step 5 viewed → generate clicked drop-off.
- Add regression coverage for explicit final-handoff labels in `StepNavigation`.

## Safety / scope
- No deploy.
- No production writes.
- No DB/PubSub/workflow/recovery/customer action.
- Does not click or trigger production Generate.

## Validation
- `npm test -- src/components/StepNavigation.test.tsx --runInBand`
- `npx eslint src/components/StepNavigation.tsx src/components/StepNavigation.test.tsx src/app/[locale]/tell-your-story/step-4/page.tsx src/app/[locale]/tell-your-story/step-5/page.tsx src/lib/analytics.ts`
- `npm run typecheck`
- `npm run i18n:parity`
- `git diff --check`
