### PR TITLE
Handle 401/403 when loading stories and add localized error messages

### DIFF
--- a/src/app/[locale]/stories/read/[storyId]/chapter/[chapterNumber]/page.tsx
+++ b/src/app/[locale]/stories/read/[storyId]/chapter/[chapterNumber]/page.tsx
@@ -61,10 +61,12 @@ export default function ReadChapterPage() {
           setStory(data.story);
           setChapters(data.chapters);
           setCurrentChapter(data.currentChapter);
+        } else if (response.status === 401) {
+          setError(tErrors('storySignInRequired'));
+        } else if (response.status === 403) {
+          setError(tErrors('storyWrongAccount'));
         } else if (response.status === 404) {
           setError(tErrors('storyNotFoundGeneric'));
-        } else if (response.status === 403) {
-          setError(tErrors('noPermission'));
         } else {
           setError(tErrors('failedToLoad'));
         }

--- a/src/app/[locale]/stories/read/[storyId]/page.tsx
+++ b/src/app/[locale]/stories/read/[storyId]/page.tsx
@@ -63,10 +63,12 @@ export default function ReadStoryPage() {
           const data = await response.json();
           setStory(data.story);
           setChapters(data.chapters);
+        } else if (response.status === 401) {
+          setLoadError(tErrors('storySignInRequired'));
+        } else if (response.status === 403) {
+          setLoadError(tErrors('storyWrongAccount'));
         } else if (response.status === 404) {
           setLoadError(tErrors('storyNotFoundGeneric'));
-        } else if (response.status === 403) {
-          setLoadError(tErrors('noPermission'));
         } else {
           setLoadError(tErrors('failedToLoad'));
         }

--- a/src/messages/de-DE/Errors.json
+++ b/src/messages/de-DE/Errors.json
@@ -5,6 +5,8 @@
     "pleaseSignIn": "Bitte melde dich an, um fortzufahren",
     "storyNotAvailableYet": "Diese Geschichte ist noch nicht verfügbar.",
     "storyNotFoundGeneric": "Geschichte nicht gefunden.",
+    "storySignInRequired": "Diese Geschichte ist gesperrt. Melde dich mit demselben Konto an, mit dem diese Geschichte erstellt wurde, und versuche den Link erneut.",
+    "storyWrongAccount": "Diese Geschichte gehört zu einem anderen Konto. Melde dich mit dem Konto an, das die Story-E-Mail erhalten hat, und öffne den Link erneut.",
     "noPermission": "Du hast keine Berechtigung, auf diese Geschichte zuzugreifen.",
     "failedToLoad": "Die Geschichte konnte nicht geladen werden. Bitte versuche es erneut.",
     "oops": "Ups!",

--- a/src/messages/en-US/Errors.json
+++ b/src/messages/en-US/Errors.json
@@ -5,6 +5,8 @@
     "pleaseSignIn": "Please sign in to continue",
     "storyNotAvailableYet": "This story is not available yet.",
     "storyNotFoundGeneric": "Story not found.",
+    "storySignInRequired": "This story is locked. Please sign in with the same account that created this story, then try the link again.",
+    "storyWrongAccount": "This story belongs to another account. Sign in with the account that received the story email, then open the link again.",
     "noPermission": "You do not have permission to access this story.",
     "failedToLoad": "Failed to load the story. Please try again.",
     "oops": "Oops!",

--- a/src/messages/es-ES/Errors.json
+++ b/src/messages/es-ES/Errors.json
@@ -5,6 +5,8 @@
     "pleaseSignIn": "Por favor, inicia sesión para continuar",
     "storyNotAvailableYet": "Esta historia aún no está disponible.",
     "storyNotFoundGeneric": "Historia no encontrada.",
+    "storySignInRequired": "Esta historia está bloqueada. Inicia sesión con la misma cuenta que creó esta historia y vuelve a probar el enlace.",
+    "storyWrongAccount": "Esta historia pertenece a otra cuenta. Inicia sesión con la cuenta que recibió el email de la historia y vuelve a abrir el enlace.",
     "noPermission": "No tienes permiso para acceder a esta historia.",
     "failedToLoad": "Error al cargar la historia. Inténtalo de nuevo.",
     "oops": "¡Vaya!",

--- a/src/messages/fr-FR/Errors.json
+++ b/src/messages/fr-FR/Errors.json
@@ -5,6 +5,8 @@
     "pleaseSignIn": "Veuillez vous connecter pour continuer",
     "storyNotAvailableYet": "Cette histoire n'est pas encore disponible.",
     "storyNotFoundGeneric": "Histoire introuvable.",
+    "storySignInRequired": "Cette histoire est verrouillée. Connectez-vous avec le même compte que celui qui a créé cette histoire, puis réessayez le lien.",
+    "storyWrongAccount": "Cette histoire appartient à un autre compte. Connectez-vous avec le compte qui a reçu l'e-mail de l'histoire, puis ouvrez à nouveau le lien.",
     "noPermission": "Vous n'avez pas la permission d'accéder à cette histoire.",
     "failedToLoad": "N'a pas réussi à charger l'histoire. Veuillez réessayer.",
     "oops": "Oups!",

--- a/src/messages/pt-PT/Errors.json
+++ b/src/messages/pt-PT/Errors.json
@@ -5,6 +5,8 @@
     "pleaseSignIn": "Por favor, inicie sessão para continuar",
     "storyNotAvailableYet": "Esta história ainda não está disponível.",
     "storyNotFoundGeneric": "História não encontrada.",
+    "storySignInRequired": "Esta história está protegida. Inicie sessão com a mesma conta que criou esta história e tente abrir o link novamente.",
+    "storyWrongAccount": "Esta história pertence a outra conta. Inicie sessão com a conta que recebeu o email da história e abra o link novamente.",
     "noPermission": "Não tem permissão para aceder a esta história.",
     "failedToLoad": "Falha ao carregar a história. Por favor, tente novamente.",
     "oops": "Ups!",

--- a/src/types/translation-keys.d.ts
+++ b/src/types/translation-keys.d.ts
@@ -1,5 +1,5 @@
 // AUTO-GENERATED FILE. Run: npm run i18n:keys
-// Total keys: 2501
+// Total keys: 2503
 export type TranslationKey =
   | 'AIEditModal.buttons.applyChanges'
   | 'AIEditModal.buttons.cancel'
@@ -715,6 +715,8 @@ export type TranslationKey =
   | 'Errors.pleaseSignIn'
   | 'Errors.storyNotAvailableYet'
   | 'Errors.storyNotFoundGeneric'
+  | 'Errors.storySignInRequired'
+  | 'Errors.storyWrongAccount'
   | 'Faq.allSections'
   | 'Faq.error'
   | 'Faq.loading'


### PR DESCRIPTION
### Motivation
- Ensure the UI surfaces clear, account/auth-specific error messages when fetching a story or chapter fails due to authentication or wrong account. 
- Provide localized error strings so callers see user-friendly guidance in multiple locales. 
- Keep translation keys in sync with the new messages.

### Description
- Added explicit `401` and `403` response handling in the chapter fetcher (`src/app/[locale]/stories/read/[storyId]/chapter/[chapterNumber]/page.tsx`) to set appropriate error messages. 
- Added explicit `401` and `403` response handling in the story fetcher (`src/app/[locale]/stories/read/[storyId]/page.tsx`) to set appropriate load error messages. 
- Added two new error translations (`storySignInRequired` and `storyWrongAccount`) to `Errors.json` for `en-US`, `de-DE`, `es-ES`, `fr-FR`, and `pt-PT`. 
- Updated the generated translation type file (`src/types/translation-keys.d.ts`) to include the two new `Errors.*` keys and increment the total key count.

### Testing
- Ran the TypeScript type check via `npm run typecheck` and the project build locally, and the build completed successfully. 
- Ran the test suite via `npm test` and all tests passed locally. 
- Verified i18n keys were regenerated and included the two new keys in `src/types/translation-keys.d.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ed90fc88c8328a5b2ec50e374d40f)