### PR TITLE
fix: align homepage hero signup path

### DIFF
--- a/src/components/papercut/compositions/kidsFantasy/index.test.ts
+++ b/src/components/papercut/compositions/kidsFantasy/index.test.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+describe('kidsFantasy hero composition', () => {
+  it('sends anonymous homepage hero starts directly to sign-up', () => {
+    const source = readFileSync(join(__dirname, 'index.ts'), 'utf8');
+
+    expect(source).toContain("ctaPath: 'sign-up'");
+    expect(source).not.toContain("ctaPath: 'tell-your-story'");
+  });
+});

--- a/src/components/papercut/compositions/kidsFantasy/index.ts
+++ b/src/components/papercut/compositions/kidsFantasy/index.ts
@@ -18,5 +18,5 @@ export const kidsFantasy: HeroComposition = {
   person: {
     bottom: { base: 10, md: 8, lg: 7 },
   },
-  ctaPath: 'tell-your-story',
+  ctaPath: 'sign-up',
 };


### PR DESCRIPTION
### Motivation

- The homepage hero for anonymous visitors pointed to the `/tell-your-story` auth-gated entry while the separate homepage CTA used `/sign-up`, creating a confusing extra step for new users.
- The goal is to make the signed-out hero CTA take anonymous users directly to the sign-up flow while leaving authenticated redirects untouched.

### Description

- Change the default kids-fantasy hero composition `ctaPath` from `tell-your-story` to `sign-up` in `src/components/papercut/compositions/kidsFantasy/index.ts` so the hero Link lands at `/${locale}/sign-up`.
- Leave the `/tell-your-story` route and its signed-in redirect behavior unchanged so authenticated users still reach `/tell-your-story/step-1`.
- Add a focused Jest regression test `src/components/papercut/compositions/kidsFantasy/index.test.ts` that asserts the composition now targets `sign-up` and no longer references `tell-your-story`.

### Testing

- Ran `npm run lint` and the linter completed successfully.
- Ran `npm run typecheck` and TypeScript checks passed with no errors.
- Executed the focused test with `npm run test -- --runTestsByPath src/components/papercut/compositions/kidsFantasy/index.test.ts` and it passed.
- Ran the full test suite with `npm run test` and all tests passed (45 passed, 2 skipped in suites observed) and `prettier` formatting check via `npm run format` also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a43cc42d4ac8328b71ec80dd244c73e)